### PR TITLE
feat(common): add step 2, connect app to bc

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,10 @@
+# Get the Client ID and Secret from the Developer Portal
+# https://developer.bigcommerce.com/api-docs/apps/quick-start#register-a-draft-app
+
+CLIENT_ID={app client id}
+CLIENT_SECRET={app secret}
+
+# Test locally with ngrok
+# https://developer.bigcommerce.com/api-docs/apps/guide/development#testing-locally-with-ngrok
+
+AUTH_CALLBACK=https://{ngrok_id}.ngrok.io/api/auth

--- a/README.md
+++ b/README.md
@@ -9,5 +9,16 @@ To get the app running locally, follow these instructions:
 1. [Use Node 10+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#checking-your-version-of-npm-and-node-js)
 2. Install npm packages
     - `npm install`
-3. Start your dev environment
+3. [Add and start ngrok.](https://www.npmjs.com/package/ngrok#usage) Note: use port 3000 to match Next's server.
+    - `npm install ngrok`
+    - `ngrok http 3000`
+4. [Register a draft app.](https://developer.bigcommerce.com/api-docs/apps/quick-start#register-a-draft-app)
+     - For steps 5-7, enter callbacks as `'https://{ngrok_id}.ngrok.io/api/{auth||load||uninstall}'`. 
+     - Get `ngrok_id` from the terminal that's running `ngrok http 3000`.
+     - e.g. auth callback: `https://12345.ngrok.io/api/auth`
+5. Copy .env-sample to `.env`.
+6. [Replace client_id and client_secret in .env](https://devtools.bigcommerce.com/my/apps) (from `View Client ID` in the dev portal).
+7. Update AUTH_CALLBACK in `.env` with the `ngrok_id` from step 5.
+8. Start your dev environment in a **separate** terminal from `ngrok`. If `ngrok` restarts, update callbacks in steps 4 and 7 with the new ngrok_id.
     - `npm run dev`
+9. [Install the app and launch.](https://developer.bigcommerce.com/api-docs/apps/quick-start#install-the-app)

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,30 @@
+import * as BigCommerce from 'node-bigcommerce';
+
+// Create BigCommerce instance
+// https://github.com/getconversio/node-bigcommerce
+const bigcommerce = new BigCommerce({
+    logLevel: 'info',
+    clientId: process.env.CLIENT_ID,
+    secret: process.env.CLIENT_SECRET,
+    callback: process.env.AUTH_CALLBACK,
+    responseType: 'json',
+    headers: { 'Accept-Encoding': '*' },
+    apiVersion: 'v3'
+});
+
+const bigcommerceSigned = new BigCommerce({
+    secret: process.env.CLIENT_SECRET,
+    responseType: 'json'
+});
+
+interface QueryParams {
+    [key: string]: string;
+}
+
+export function getBCAuth(query: QueryParams) {
+    return bigcommerce.authorize(query);
+}
+
+export function getBCVerify({ signed_payload }: QueryParams) {
+    return bigcommerceSigned.verify(signed_payload);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2001,6 +2001,24 @@
       "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
       "optional": true
     },
+    "node-bigcommerce": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/node-bigcommerce/-/node-bigcommerce-4.1.0.tgz",
+      "integrity": "sha512-cNgDjeDO4kQ2TLnxPd/5hN7Xd8gqK+c/M+6lISlAIPPzbqnJnT7yISYv+BYAHPWJOhD1p1ozp9+Je73cX9HZjw==",
+      "requires": {
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@bigcommerce/big-design": "^0.27.0",
     "next": "^10.0.5",
+    "node-bigcommerce": "^4.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "styled-components": "^4.4.1"

--- a/pages/api/auth.ts
+++ b/pages/api/auth.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getBCAuth } from '../../lib/auth';
+
+export default async function auth(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        await getBCAuth(req.query);
+
+        res.redirect(302, '/');
+    } catch (error) {
+        const { data, response } = error;
+        res.status(response?.status || 500).json(data);
+    }
+}

--- a/pages/api/load.ts
+++ b/pages/api/load.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getBCVerify } from '../../lib/auth';
+
+export default async function load(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        await getBCVerify(req.query);
+
+        res.redirect(302, '/');
+    } catch (error) {
+        const { data, response } = error;
+        res.status(response?.status || 500).json(data);
+    }
+}

--- a/pages/api/uninstall.ts
+++ b/pages/api/uninstall.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getBCVerify } from '../../lib/auth';
+
+export default async function uninstall(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        await getBCVerify(req.query);
+
+        res.status(200).end();
+    } catch (error) {
+        const { data, response } = error;
+        res.status(response?.status || 500).json(data);
+    }
+}


### PR DESCRIPTION
## What?
Expands on the foundation step - connects the sample app to BigCommerce using the `node-bigcommerce` API client.

This PR includes:
- auth, load, and uninstall callback endpoints
- node-bigcommerce package
- auth middleware to verify and authorize the app
- .env-sample with sample environment variables
- expanded readme

**NOTE**: will squash the commits before merging

## Why?
required for step 2 of the dev tutorial

## Testing / Proof
tested locally by running `npm install`, running `npm run dev`, `ngrok` and verifying output on a BigCommerce store app page