### PR TITLE
feat(common): add step 3, integrate bc api

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -8,3 +8,8 @@ CLIENT_SECRET={app secret}
 # https://developer.bigcommerce.com/api-docs/apps/guide/development#testing-locally-with-ngrok
 
 AUTH_CALLBACK=https://{ngrok_id}.ngrok.io/api/auth
+
+# Set cookie variables, replace jwt key with a 32+ random character secret
+
+COOKIE_NAME=__{NAME}
+JWT_KEY={SECRET}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ To get the app running locally, follow these instructions:
 5. Copy .env-sample to `.env`.
 6. [Replace client_id and client_secret in .env](https://devtools.bigcommerce.com/my/apps) (from `View Client ID` in the dev portal).
 7. Update AUTH_CALLBACK in `.env` with the `ngrok_id` from step 5.
-8. Start your dev environment in a **separate** terminal from `ngrok`. If `ngrok` restarts, update callbacks in steps 4 and 7 with the new ngrok_id.
+8. Enter a cookie name, as well as a jwt secret in `.env`.
+    - The cookie name should be unique
+    - JWT key should be at least 32 random characters (256 bits) for HS256
+9. Start your dev environment in a **separate** terminal from `ngrok`. If `ngrok` restarts, update callbacks in steps 4 and 7 with the new ngrok_id.
     - `npm run dev`
-9. [Install the app and launch.](https://developer.bigcommerce.com/api-docs/apps/quick-start#install-the-app)
+10. [Install the app and launch.](https://developer.bigcommerce.com/api-docs/apps/quick-start#install-the-app)

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,20 @@
+import { H2, Link } from '@bigcommerce/big-design';
+import { useStore } from '../lib/hooks';
+
+interface HeaderProps {
+    title: string;
+}
+
+const Header = ({ title }: HeaderProps) => {
+    const { storeId } = useStore();
+    const storeLink = `https://store-${storeId}.mybigcommerce.com/manage/marketplace/apps/my-apps`;
+
+    return (
+        <>
+            <Link href={storeLink}>My Apps</Link>
+            <H2 marginTop="medium">{title}</H2>
+        </>
+    );
+};
+
+export default Header;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,24 +1,33 @@
 import * as BigCommerce from 'node-bigcommerce';
+import { QueryParams } from '../types';
+
+const { AUTH_CALLBACK, CLIENT_ID, CLIENT_SECRET } = process.env;
 
 // Create BigCommerce instance
 // https://github.com/getconversio/node-bigcommerce
 const bigcommerce = new BigCommerce({
     logLevel: 'info',
-    clientId: process.env.CLIENT_ID,
-    secret: process.env.CLIENT_SECRET,
-    callback: process.env.AUTH_CALLBACK,
+    clientId: CLIENT_ID,
+    secret: CLIENT_SECRET,
+    callback: AUTH_CALLBACK,
     responseType: 'json',
     headers: { 'Accept-Encoding': '*' },
     apiVersion: 'v3'
 });
 
 const bigcommerceSigned = new BigCommerce({
-    secret: process.env.CLIENT_SECRET,
+    secret: CLIENT_SECRET,
     responseType: 'json'
 });
 
-interface QueryParams {
-    [key: string]: string;
+export function bigcommerceClient(accessToken: string, storeId: string) {
+    return new BigCommerce({
+        clientId: CLIENT_ID,
+        accessToken,
+        storeHash: storeId,
+        responseType: 'json',
+        apiVersion: 'v3'
+    });
 }
 
 export function getBCAuth(query: QueryParams) {

--- a/lib/cookie.ts
+++ b/lib/cookie.ts
@@ -1,0 +1,40 @@
+import { parse, serialize } from 'cookie';
+import * as jwt from 'jsonwebtoken';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { SessionProps } from '../types';
+
+const { COOKIE_NAME, JWT_KEY } = process.env;
+const MAX_AGE = 60 * 60 * 24; // 24 hours
+
+export function setCookie(res: NextApiResponse, session: SessionProps) {
+    const { access_token: token, context } = session;
+    const storeId = context?.split('/')[1] || '';
+    const cookie = serialize(COOKIE_NAME, encode(token, storeId), {
+        expires: new Date(Date.now() + MAX_AGE * 1000),
+        httpOnly: true,
+        path: '/',
+        sameSite: 'none',
+        secure: true,
+    });
+
+    res.setHeader('Set-Cookie', cookie);
+}
+
+export function parseCookies(req: NextApiRequest) {
+    if (req.cookies) return req.cookies; // API routes don't parse cookies
+
+    const cookie = req.headers?.cookie;
+    return parse(cookie || '');
+}
+
+export function getCookie(req: NextApiRequest) {
+    return parseCookies(req)[COOKIE_NAME];
+}
+
+export function encode(token: string, storeId: string) {
+    return jwt.sign({ accessToken: token, storeId }, JWT_KEY);
+}
+
+export function decode(encodedCookie: string) {
+    return jwt.verify(encodedCookie, JWT_KEY);
+}

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,0 +1,23 @@
+import useSWR from 'swr';
+
+function fetcher(url: string) {
+    return fetch(url).then(res => res.json());
+}
+
+export function useStore() {
+    const { data, error } = useSWR('/api/store', fetcher);
+
+    return {
+        storeId: data?.storeId,
+        isError: error,
+    };
+}
+
+export function useProducts() {
+    const { data, error } = useSWR('/api/products', fetcher);
+
+    return {
+        summary: data,
+        isError: error,
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -816,6 +816,11 @@
         "ieee754": "^1.1.4"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -999,6 +1004,11 @@
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1231,6 +1241,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -1310,6 +1325,14 @@
         "compute-scroll-into-view": "^1.0.14",
         "prop-types": "^15.7.2",
         "react-is": "^16.13.1"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "electron-to-chromium": {
@@ -1767,6 +1790,49 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "line-column": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
@@ -1798,6 +1864,41 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -2977,6 +3078,14 @@
       "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "swr": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.4.1.tgz",
+      "integrity": "sha512-/jQWPjCwy7rNbEJKpuObfbtJHtneTKhlzjy8VkuAEGg/kkYhZoKWVdGtIXrz9vuTGdy/grLVWpA6DfiNk9ECWg==",
+      "requires": {
+        "dequal": "2.0.2"
       }
     },
     "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,14 @@
   "license": "ISC",
   "dependencies": {
     "@bigcommerce/big-design": "^0.27.0",
+    "cookie": "^0.4.1",
+    "jsonwebtoken": "^8.5.1",
     "next": "^10.0.5",
     "node-bigcommerce": "^4.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "styled-components": "^4.4.1"
+    "styled-components": "^4.4.1",
+    "swr": "^0.4.1"
   },
   "devDependencies": {
     "@types/node": "^14.14.22",

--- a/pages/api/auth.ts
+++ b/pages/api/auth.ts
@@ -1,13 +1,16 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getBCAuth } from '../../lib/auth';
+import { setCookie } from '../../lib/cookie';
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
     try {
-        await getBCAuth(req.query);
+        // Authenticate the app on install
+        const session = await getBCAuth(req.query);
 
+        setCookie(res, session);
         res.redirect(302, '/');
     } catch (error) {
-        const { data, response } = error;
-        res.status(response?.status || 500).json(data);
+        const { message, response } = error;
+        res.status(response?.status || 500).json(message);
     }
 }

--- a/pages/api/load.ts
+++ b/pages/api/load.ts
@@ -7,7 +7,7 @@ export default async function load(req: NextApiRequest, res: NextApiResponse) {
 
         res.redirect(302, '/');
     } catch (error) {
-        const { data, response } = error;
-        res.status(response?.status || 500).json(data);
+        const { message, response } = error;
+        res.status(response?.status || 500).json(message);
     }
 }

--- a/pages/api/products/index.ts
+++ b/pages/api/products/index.ts
@@ -1,0 +1,17 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { bigcommerceClient } from '../../../lib/auth';
+import { decode, getCookie } from '../../../lib/cookie';
+
+export default async function products(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const cookies = getCookie(req);
+        const { accessToken, storeId } = (cookies && decode(cookies)) ?? null;
+        const bigcommerce = bigcommerceClient(accessToken, storeId);
+
+        const { data } = await bigcommerce.get('/catalog/summary');
+        res.status(200).json(data);
+    } catch (error) {
+        const { message, response } = error;
+        res.status(response?.status || 500).end(message || 'Authentication failed, please re-install');
+    }
+}

--- a/pages/api/store/index.ts
+++ b/pages/api/store/index.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { decode, getCookie } from '../../../lib/cookie';
+
+export default async function store(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const cookies = getCookie(req);
+        const { storeId } = (cookies && decode(cookies)) ?? null;
+
+        res.status(200).json({ storeId });
+    } catch (error) {
+        res.status(500).end('Authentication failed, please re-install');
+    }
+}

--- a/pages/api/uninstall.ts
+++ b/pages/api/uninstall.ts
@@ -7,7 +7,7 @@ export default async function uninstall(req: NextApiRequest, res: NextApiRespons
 
         res.status(200).end();
     } catch (error) {
-        const { data, response } = error;
-        res.status(response?.status || 500).json(data);
+        const { message, response } = error;
+        res.status(response?.status || 500).json(message);
     }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,31 @@
-import { Panel, Text } from '@bigcommerce/big-design';
+import { Box, Flex, Panel, Text } from '@bigcommerce/big-design';
+import Header from '../components/header';
+import { useProducts } from '../lib/hooks';
 
-const Index = () => (
-    <Panel header="Homepage" margin="xxLarge">
-        <Text>Hello world</Text>
-    </Panel>
-);
+const Index = () => {
+    const { summary } = useProducts();
+
+    return (
+        <Panel margin="xxLarge">
+            <Header title="Homepage" />
+            {summary &&
+                <Flex>
+                    <Box marginRight="xLarge">
+                        <Text>Inventory Count</Text>
+                        <Text>{summary.inventory_count}</Text>
+                    </Box>
+                    <Box marginRight="xLarge">
+                        <Text>Variant Count</Text>
+                        <Text>{summary.variant_count}</Text>
+                    </Box>
+                    <Box>
+                        <Text>Primary Category</Text>
+                        <Text>{summary.primary_category_name}</Text>
+                    </Box>
+                </Flex>
+            }
+        </Panel>
+    );
+};
 
 export default Index;

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,0 +1,16 @@
+export interface User {
+    id: number;
+    username: string;
+    email: string;
+}
+
+export interface SessionProps {
+    access_token: string;
+    scope: string;
+    user: User;
+    context: string;
+}
+
+export interface QueryParams {
+    [key: string]: string;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,1 @@
+export * from './auth';


### PR DESCRIPTION
## What?
Expands on the previous step - integrates BigCommerce API calls using cookies

This PR includes:
- updated auth endpoint to set auth cookie
- adds cookie, jsonwebtoken, and swr packages
- includes store endpoint to read storeHash from cookie
- new products api to fetch product summary (used on homepage)
- .env-sample expanded with cookie and jwt variables
- revised readme

<img width="806" alt="Screen Shot 2021-02-05 at 12 37 51 PM" src="https://user-images.githubusercontent.com/38708175/107086537-0376ff00-67af-11eb-9de1-afb15db1c424.png">


## Why?
required for step 3 of the dev tutorial

## Testing / Proof
tested locally by running `npm install`, running `npm run dev`, `ngrok` and verifying output on a BigCommerce store app page