### PR TITLE
Step 5 big design part 2

### DIFF
--- a/components/error.tsx
+++ b/components/error.tsx
@@ -1,0 +1,14 @@
+import { H3, Panel } from '@bigcommerce/big-design';
+
+interface ErrorMessageProps {
+    error?: Error;
+}
+
+const ErrorMessage = ({ error }: ErrorMessageProps) => (
+    <Panel>
+        <H3>Failed to load</H3>
+        {error && error.message}
+    </Panel>
+);
+
+export default ErrorMessage;

--- a/components/form.tsx
+++ b/components/form.tsx
@@ -1,0 +1,126 @@
+import { Button, Checkbox, Flex, FormGroup, Input, Panel, Select, Form as StyledForm, Textarea } from '@bigcommerce/big-design';
+import { ChangeEvent, FormEvent, useState } from 'react';
+import { FormData, StringKeyValue } from '../types';
+
+interface FormProps {
+    formData: FormData;
+    onCancel(): void;
+    onSubmit(form: FormData): void;
+}
+
+const FormErrors = {
+    name: 'Product name is required',
+    price: 'Default price is required',
+};
+
+const Form = ({ formData, onCancel, onSubmit }: FormProps) => {
+    const { description, isVisible, name, price, type } = formData;
+    const [form, setForm] = useState<FormData>({ description, isVisible, name, price, type });
+    const [errors, setErrors] = useState<StringKeyValue>({});
+
+    const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        const { name: formName, value } = event?.target;
+        setForm(prevForm => ({ ...prevForm, [formName]: value }));
+
+        // Add error if it exists in FormErrors and the input is empty, otherwise remove from errors
+        !value && FormErrors[formName]
+            ? setErrors(prevErrors => ({ ...prevErrors, [formName]: FormErrors[formName] }))
+            : setErrors(({ [formName]: removed, ...prevErrors }) => ({ ...prevErrors }));
+    };
+
+    const handleSelectChange = (value: string) => {
+        setForm(prevForm => ({ ...prevForm, type: value }));
+    };
+
+    const handleCheckboxChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const { checked, name: formName } = event?.target;
+        setForm(prevForm => ({ ...prevForm, [formName]: checked }));
+    };
+
+    const handleSubmit = (event: FormEvent<EventTarget>) => {
+        event.preventDefault();
+
+        // If there are errors, do not submit the form
+        const hasErrors = Object.keys(errors).length > 0;
+        if (hasErrors) return;
+
+        onSubmit(form);
+    };
+
+    return (
+        <StyledForm onSubmit={handleSubmit}>
+            <Panel header="Basic Information">
+                <FormGroup>
+                    <Input
+                        error={errors?.name}
+                        label="Product name"
+                        name="name"
+                        required
+                        value={form.name}
+                        onChange={handleChange}
+                    />
+                </FormGroup>
+                <FormGroup>
+                    <Select
+                        label="Product type"
+                        name="type"
+                        options={[
+                            { value: 'physical', content: 'Physical' },
+                            { value: 'digital', content: 'Digital' }
+                        ]}
+                        required
+                        value={form.type}
+                        onOptionChange={handleSelectChange}
+                    />
+                </FormGroup>
+                <FormGroup>
+                    <Input
+                        error={errors?.price}
+                        iconLeft={'$'}
+                        label="Default price (excluding tax)"
+                        name="price"
+                        placeholder="10.00"
+                        required
+                        type="number"
+                        step="0.01"
+                        value={form.price}
+                        onChange={handleChange}
+                    />
+                </FormGroup>
+                <FormGroup>
+                    <Checkbox
+                        name="isVisible"
+                        checked={form.isVisible}
+                        onChange={handleCheckboxChange}
+                        label="Visible on storefront"
+                    />
+                </FormGroup>
+            </Panel>
+            <Panel header="Description">
+                <FormGroup>
+                    {/* Using description for demo purposes. Consider using a wysiwig instead (e.g. TinyMCE) */}
+                    <Textarea
+                        label="Description"
+                        name="description"
+                        placeholder="Product info"
+                        value={form.description}
+                        onChange={handleChange}
+                    />
+                </FormGroup>
+            </Panel>
+            <Flex justifyContent="flex-end">
+                <Button
+                    marginRight="medium"
+                    type="button"
+                    variant="subtle"
+                    onClick={onCancel}
+                >
+                    Cancel
+                </Button>
+                <Button type="submit">Save</Button>
+            </Flex>
+        </StyledForm>
+    );
+};
+
+export default Form;

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,6 +1,7 @@
 import { Box, Tabs } from '@bigcommerce/big-design';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import InnerHeader from './innerHeader';
 
 const TabIds = {
     HOME: 'home',
@@ -12,17 +13,33 @@ const TabRoutes = {
     [TabIds.PRODUCTS]: '/products',
 };
 
+const InnerRoutes = [
+    '/products/[pid]',
+];
+
+const HeaderTypes = {
+    GLOBAL: 'global',
+    INNER: 'inner',
+};
+
 const Header = () => {
-    const [activeTab, setActiveTab] = useState(TabIds.HOME);
+    const [activeTab, setActiveTab] = useState<string>('');
+    const [headerType, setHeaderType] = useState<string>(HeaderTypes.GLOBAL);
     const router = useRouter();
     const { pathname } = router;
 
     useEffect(() => {
-        // Check if new route matches TabRoutes
-        const tabKey = Object.keys(TabRoutes).find(key => TabRoutes[key] === pathname);
+        if (InnerRoutes.includes(pathname)) {
+            // Use InnerHeader if route matches inner routes
+            setHeaderType(HeaderTypes.INNER);
+        } else {
+            // Check if new route matches TabRoutes
+            const tabKey = Object.keys(TabRoutes).find(key => TabRoutes[key] === pathname);
 
-        // Set the active tab to tabKey or set no active tab if route doesn't match (404)
-        setActiveTab(tabKey ?? '');
+            // Set the active tab to tabKey or set no active tab if route doesn't match (404)
+            setActiveTab(tabKey ?? '');
+            setHeaderType(HeaderTypes.GLOBAL);
+        }
 
     }, [pathname]);
 
@@ -41,6 +58,8 @@ const Header = () => {
 
         return router.push(TabRoutes[tabId]);
     };
+
+    if (headerType === HeaderTypes.INNER) return <InnerHeader />;
 
     return (
         <Box marginBottom="xxLarge">

--- a/components/innerHeader.tsx
+++ b/components/innerHeader.tsx
@@ -1,0 +1,27 @@
+import { Box, Button, H1, HR, Text } from '@bigcommerce/big-design';
+import { ArrowBackIcon } from '@bigcommerce/big-design-icons';
+import { useRouter } from 'next/router';
+import { useProductList } from '../lib/hooks';
+
+const InnerHeader = () => {
+    const router = useRouter();
+    const { pid } = router.query;
+    const { list = [] } = useProductList();
+    const { name } = list.find(item => item.id === Number(pid)) ?? {};
+
+    const handleBackClick = () => router.back();
+
+    return (
+        <Box marginBottom="xxLarge">
+            <Button iconLeft={<ArrowBackIcon color="secondary50" />} variant="subtle" onClick={handleBackClick}>
+                <Text bold color="secondary50">Products</Text>
+            </Button>
+            {name &&
+                <H1>{name}</H1>
+            }
+            <HR color="secondary30" />
+        </Box>
+    );
+};
+
+export default InnerHeader;

--- a/components/loading.tsx
+++ b/components/loading.tsx
@@ -1,0 +1,12 @@
+import { Flex, H3, Panel, ProgressCircle } from '@bigcommerce/big-design';
+
+const Loading = () => (
+    <Panel>
+        <H3>Loading...</H3>
+        <Flex justifyContent="center" alignItems="center">
+            <ProgressCircle size="large" />
+        </Flex>
+    </Panel>
+);
+
+export default Loading;

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -12,15 +12,18 @@ export function useProducts() {
 
     return {
         summary: data,
+        isLoading: !data && !error,
         isError: error,
     };
 }
 
 export function useProductList() {
-    const { data, error } = useSWR('/api/products/list', fetcher);
+    const { data, error, mutate: mutateList } = useSWR('/api/products/list', fetcher);
 
     return {
         list: data,
+        isLoading: !data && !error,
         isError: error,
+        mutateList,
     };
 }

--- a/pages/api/products/[pid].ts
+++ b/pages/api/products/[pid].ts
@@ -1,0 +1,20 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { bigcommerceClient, getSession } from '../../../lib/auth';
+
+export default async function products(req: NextApiRequest, res: NextApiResponse) {
+    const {
+        body,
+        query: { pid },
+    } = req;
+
+    try {
+        const { accessToken, storeId } = await getSession(req);
+        const bigcommerce = bigcommerceClient(accessToken, storeId);
+
+        const { data } = await bigcommerce.put(`/catalog/products/${pid}`, body);
+        res.status(200).json(data);
+    } catch (error) {
+        const { message, response } = error;
+        res.status(response?.status || 500).end(message || 'Authentication failed, please re-install');
+    }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,28 +1,29 @@
-import { Box, Flex, H1, H2, H4, Link, Panel } from '@bigcommerce/big-design';
+import { Box, Flex, H1, H4, Panel } from '@bigcommerce/big-design';
 import styled from 'styled-components';
+import Loading from '../components/loading';
 import { useProducts } from '../lib/hooks';
 
 const Index = () => {
-    const { summary } = useProducts();
+    const { isLoading, summary } = useProducts();
+
+    if (isLoading) return <Loading />;
 
     return (
         <Panel header="Homepage">
-            {summary &&
-                <Flex>
-                    <StyledBox border="box" borderRadius="normal" marginRight="xLarge" padding="medium">
-                        <H4>Inventory count</H4>
-                        <H1 marginBottom="none">{summary.inventory_count}</H1>
-                    </StyledBox>
-                    <StyledBox border="box" borderRadius="normal" marginRight="xLarge" padding="medium">
-                        <H4>Variant count</H4>
-                        <H1 marginBottom="none">{summary.variant_count}</H1>
-                    </StyledBox>
-                    <StyledBox border="box" borderRadius="normal" padding="medium">
-                        <H4>Primary category</H4>
-                        <H1 marginBottom="none">{summary.primary_category_name}</H1>
-                    </StyledBox>
-                </Flex>
-            }
+            <Flex>
+                <StyledBox border="box" borderRadius="normal" marginRight="xLarge" padding="medium">
+                    <H4>Inventory count</H4>
+                    <H1 marginBottom="none">{summary.inventory_count}</H1>
+                </StyledBox>
+                <StyledBox border="box" borderRadius="normal" marginRight="xLarge" padding="medium">
+                    <H4>Variant count</H4>
+                    <H1 marginBottom="none">{summary.variant_count}</H1>
+                </StyledBox>
+                <StyledBox border="box" borderRadius="normal" padding="medium">
+                    <H4>Primary category</H4>
+                    <H1 marginBottom="none">{summary.primary_category_name}</H1>
+                </StyledBox>
+            </Flex>
         </Panel>
     );
 };

--- a/pages/products/[pid].tsx
+++ b/pages/products/[pid].tsx
@@ -1,0 +1,48 @@
+import { useRouter } from 'next/router';
+import ErrorMessage from '../../components/error';
+import Form from '../../components/form';
+import Loading from '../../components/loading';
+import { useProductList } from '../../lib/hooks';
+import { FormData } from '../../types';
+
+const ProductInfo = () => {
+    const router = useRouter();
+    const { pid } = router.query;
+    const { isError, isLoading, list = [], mutateList } = useProductList();
+    const product = list.find(item => item.id === Number(pid));
+    const { description, is_visible: isVisible, name, price, type } = product ?? {};
+    const formData = { description, isVisible, name, price, type };
+
+    const handleCancel = () => router.push('/products');
+
+    const handleSubmit = async (data: FormData) => {
+        try {
+            const filteredList = list.filter(item => item.id !== Number(pid));
+            // Update local data immediately (reduce latency to user)
+            mutateList([...filteredList, { ...product, ...data }], false);
+
+            // Update product details
+            await fetch(`/api/products/${pid}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+
+            // Refetch to validate local data
+            mutateList();
+
+            router.push('/products');
+        } catch (error) {
+            console.error('Error updating the product: ', error);
+        }
+    };
+
+    if (isLoading) return <Loading />;
+    if (isError) return <ErrorMessage />;
+
+    return (
+        <Form formData={formData} onCancel={handleCancel} onSubmit={handleSubmit} />
+    );
+};
+
+export default ProductInfo;

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -1,11 +1,15 @@
 import { Button, Dropdown, Panel, Small, StatefulTable, Link as StyledLink } from '@bigcommerce/big-design';
 import { MoreHorizIcon } from '@bigcommerce/big-design-icons';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { ReactElement } from 'react';
+import ErrorMessage from '../../components/error';
+import Loading from '../../components/loading';
 import { useProductList } from '../../lib/hooks';
 
 const Products = () => {
-    const { list = [] } = useProductList();
+    const router = useRouter();
+    const { isError, isLoading, list = [] } = useProductList();
     const tableItems = list.map(({ id, inventory_level: stock, name, price }) => ({
         id,
         name,
@@ -13,8 +17,8 @@ const Products = () => {
         stock,
     }));
 
-    const renderName = (name: string): ReactElement => (
-        <Link href="#">
+    const renderName = (id: number, name: string): ReactElement => (
+        <Link href={`/products/${id}`}>
             <StyledLink>{name}</StyledLink>
         </Link>
     );
@@ -28,21 +32,24 @@ const Products = () => {
         : <Small bold marginBottom="none" color="danger">0</Small>
     );
 
-    const renderAction = (): ReactElement => (
+    const renderAction = (id: number): ReactElement => (
         <Dropdown
-            items={[ { content: 'Edit product', onItemClick: (item) => item, hash: 'edit' } ]}
+            items={[ { content: 'Edit product', onItemClick: () => router.push(`/products/${id}`), hash: 'edit' } ]}
             toggle={<Button iconOnly={<MoreHorizIcon color="secondary60" />} variant="subtle" />}
         />
     );
+
+    if (isLoading) return <Loading />;
+    if (isError) return <ErrorMessage />;
 
     return (
         <Panel>
             <StatefulTable
                 columns={[
-                    { header: 'Product name', hash: 'name', render: ({ name }) => renderName(name), sortKey: 'name' },
+                    { header: 'Product name', hash: 'name', render: ({ id, name }) => renderName(id, name), sortKey: 'name' },
                     { header: 'Stock', hash: 'stock', render: ({ stock }) => renderStock(stock), sortKey: 'stock' },
                     { header: 'Price', hash: 'price', render: ({ price }) => renderPrice(price), sortKey: 'price' },
-                    { header: 'Action', hideHeader: true, hash: 'id', render: () => renderAction() },
+                    { header: 'Action', hideHeader: true, hash: 'id', render: ({ id }) => renderAction(id), sortKey: 'id' },
                 ]}
                 items={tableItems}
                 itemName="Products"

--- a/types/data.ts
+++ b/types/data.ts
@@ -1,0 +1,11 @@
+export interface FormData {
+    description: string;
+    isVisible: boolean;
+    name: string;
+    price: number;
+    type: string;
+}
+
+export interface StringKeyValue {
+    [key: string]: string;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
+export * from './data';
 export * from './firebase';


### PR DESCRIPTION
## What?
Expands on Step 5, part 1 - showcases a rich UI experience using BigDesign.

NOTE: will squash the commits once [part 1](https://github.com/bigcommerce/sample-app-nodejs/pull/9) has been merged.

This PR includes:
- adds a new product edit page, using BigDesign's Form
- provides basic form validation with errors
- includes a new `InnerHeader` component for inner pages (i.e. product edit page)
- refactors the header component to use InnerHeader if applicable
- new API endpoint to PUT new product edits
- creates new components for loading and error states
- expands typescript interfaces

NEW PRODUCT EDIT PAGE:
<img width="1420" alt="Screen Shot 2021-03-01 at 2 42 11 PM" src="https://user-images.githubusercontent.com/38708175/109568844-584f2200-7a9c-11eb-860f-d6ffa50a07ba.png">


FORM VALIDATION:
<img width="485" alt="Screen Shot 2021-02-26 at 11 02 07 AM" src="https://user-images.githubusercontent.com/38708175/109355010-77974680-7833-11eb-8c67-1d57c169ea40.png">


## Why?
required for step 5 of the dev tutorial

## Testing / Proof
verified on BigCommerce by installing, loading, and uninstalling the app; confirmed production build and TypeScript by running `npm run build`