### PR TITLE
feat(common): moves accessToken out of cookies

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -53,7 +53,12 @@ export async function setSession(req: NextApiRequest, res: NextApiResponse, sess
 
 export async function getSession(req: NextApiRequest) {
     const cookies = getCookie(req);
-    if (cookies) return decode(cookies);
+    if (cookies) {
+        const cookieData = decode(cookies);
+        const accessToken = await fire.getStoreToken(cookieData?.storeId);
+
+        return { ...cookieData, accessToken };
+    }
 
     return await fire.getStore();
 }

--- a/lib/cookie.ts
+++ b/lib/cookie.ts
@@ -2,21 +2,15 @@ import { parse, serialize } from 'cookie';
 import * as jwt from 'jsonwebtoken';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { SessionProps } from '../types';
-import * as fire from './firebase';
 
 const { COOKIE_NAME, JWT_KEY } = process.env;
 const MAX_AGE = 60 * 60 * 24; // 24 hours
 
 export async function setCookie(res: NextApiResponse, session: SessionProps) {
-    let { access_token: token, scope } = session;
-    const { context } = session;
+    const { context, scope } = session;
     const storeId = context?.split('/')[1] || '';
 
-    if (!token) {
-        ({ accessToken: token, scope } = await fire.getStore());
-    }
-
-    const cookie = serialize(COOKIE_NAME, encode(token, scope, storeId), {
+    const cookie = serialize(COOKIE_NAME, encode(scope, storeId), {
         expires: new Date(Date.now() + MAX_AGE * 1000),
         httpOnly: true,
         path: '/',
@@ -45,8 +39,8 @@ export function removeCookie(res: NextApiResponse) {
     res.setHeader('Set-Cookie', cookie);
 }
 
-export function encode(token: string, scope: string, storeId: string) {
-    return jwt.sign({ accessToken: token, scope, storeId }, JWT_KEY);
+export function encode(scope: string, storeId: string) {
+    return jwt.sign({ scope, storeId }, JWT_KEY);
 }
 
 export function decode(encodedCookie: string) {

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -57,6 +57,13 @@ export async function getStore() {
     return storeDoc.exists ? storeData : null;
 }
 
+export async function getStoreToken(storeId: string) {
+    if (!storeId) return null;
+    const storeDoc = await db.collection('store').doc(storeId).get();
+
+    return storeDoc.exists ? storeDoc.data()?.accessToken : null;
+}
+
 export async function deleteStore({ store_hash: storeId }: SessionProps) {
     const ref = db.collection('store').doc(storeId);
 


### PR DESCRIPTION
## What?
Moves the OAUTH accessToken out of the cookie for security reasons.  Instead, we make an optimized call to the db to retrieve the access token.

NOTES:
- Technically, we could eliminate cookies altogether, but doing so would require merging Step 3 of the tutorial with Step 4 and redoing the dev docs.  There are some advantages to retaining cookies: 1) it's easier to get up and running with the BC API; 2) it's still fairly standard practice to store non-sensitive data (e.g. scope, storeId) in a cookie for faster retrieval; 3) it eliminates having a very lengthy DB step and 4) the lookup for just the storeID vs all of the store's data is technically faster.

This PR includes:
- removal of accessToken from the cookie
- revised getSession auth (combines cookie data with accessToken from the DB)
- an optimized firebase function to retrieve the accessToken

## Why?
required for security purposes

## Testing / Proof
verified on BigCommerce by installing, loading, and uninstalling the app; confirmed production build and TypeScript by running `npm run build`