### PR TITLE
fix(common): fixes deep linking into products

### DIFF
--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,4 +1,5 @@
 import useSWR from 'swr';
+import { ListItem } from '../types';
 
 function fetcher(url: string) {
     return fetch(url).then(res => res.json());
@@ -18,12 +19,25 @@ export function useProducts() {
 }
 
 export function useProductList() {
-    const { data, error, mutate: mutateList } = useSWR('/api/products/list', fetcher);
+    const options = { revalidateOnMount: false }; // Disable auto validation when switching pages
+    const { data, error, mutate: mutateList } = useSWR('/api/products/list', fetcher, options);
 
     return {
         list: data,
         isLoading: !data && !error,
         isError: error,
         mutateList,
+    };
+}
+
+export function useProductInfo(pid: number, list: ListItem[]) {
+    const product = list.find(item => item.id === pid);
+    // Conditionally fetch product if it doesn't exist in the list (e.g. deep linking)
+    const { data, error } = useSWR(!product ? `/api/products/${pid}` : null, fetcher);
+
+    return {
+        product: product ?? data,
+        isLoading: product ? false : (!data && !error),
+        isError: error,
     };
 }

--- a/pages/api/products/[pid].ts
+++ b/pages/api/products/[pid].ts
@@ -5,16 +5,38 @@ export default async function products(req: NextApiRequest, res: NextApiResponse
     const {
         body,
         query: { pid },
+        method,
     } = req;
 
-    try {
-        const { accessToken, storeId } = await getSession(req);
-        const bigcommerce = bigcommerceClient(accessToken, storeId);
+    switch (method) {
+        case 'GET':
+            try {
+                const { accessToken, storeId } = await getSession(req);
+                const bigcommerce = bigcommerceClient(accessToken, storeId);
 
-        const { data } = await bigcommerce.put(`/catalog/products/${pid}`, body);
-        res.status(200).json(data);
-    } catch (error) {
-        const { message, response } = error;
-        res.status(response?.status || 500).end(message || 'Authentication failed, please re-install');
+                const { data } = await bigcommerce.get(`/catalog/products/${pid}`);
+                res.status(200).json(data);
+            } catch (error) {
+                const { message, response } = error;
+                res.status(response?.status || 500).end(message || 'Authentication failed, please re-install');
+            }
+            break;
+        case 'PUT':
+            try {
+                const { accessToken, storeId } = await getSession(req);
+                const bigcommerce = bigcommerceClient(accessToken, storeId);
+
+                const { data } = await bigcommerce.put(`/catalog/products/${pid}`, body);
+                res.status(200).json(data);
+            } catch (error) {
+                const { message, response } = error;
+                res.status(response?.status || 500).end(message || 'Authentication failed, please re-install');
+            }
+            break;
+        default:
+            res.setHeader('Allow', ['GET', 'PUT']);
+            res.status(405).end(`Method ${method} Not Allowed`);
     }
+
+
 }

--- a/pages/products/[pid].tsx
+++ b/pages/products/[pid].tsx
@@ -2,14 +2,14 @@ import { useRouter } from 'next/router';
 import ErrorMessage from '../../components/error';
 import Form from '../../components/form';
 import Loading from '../../components/loading';
-import { useProductList } from '../../lib/hooks';
+import { useProductInfo, useProductList } from '../../lib/hooks';
 import { FormData } from '../../types';
 
 const ProductInfo = () => {
     const router = useRouter();
-    const { pid } = router.query;
+    const pid = Number(router.query?.pid);
     const { isError, isLoading, list = [], mutateList } = useProductList();
-    const product = list.find(item => item.id === Number(pid));
+    const { isLoading: isInfoLoading, product } = useProductInfo(pid, list);
     const { description, is_visible: isVisible, name, price, type } = product ?? {};
     const formData = { description, isVisible, name, price, type };
 
@@ -17,7 +17,7 @@ const ProductInfo = () => {
 
     const handleSubmit = async (data: FormData) => {
         try {
-            const filteredList = list.filter(item => item.id !== Number(pid));
+            const filteredList = list.filter(item => item.id !== pid);
             // Update local data immediately (reduce latency to user)
             mutateList([...filteredList, { ...product, ...data }], false);
 
@@ -37,7 +37,7 @@ const ProductInfo = () => {
         }
     };
 
-    if (isLoading) return <Loading />;
+    if (isLoading || isInfoLoading) return <Loading />;
     if (isError) return <ErrorMessage />;
 
     return (

--- a/test/mocks/hooks.ts
+++ b/test/mocks/hooks.ts
@@ -1,14 +1,14 @@
 import { TableItem } from '@types';
 
 // useProducts Mock
-const summaryData = {
+const summaryMock = {
     inventory_count: 3,
     variant_count: 2,
     primary_category_name: 'widgets',
 };
 
 export const useProducts = jest.fn().mockImplementation(() => ({
-    summary: summaryData,
+    summary: summaryMock,
 }));
 
 // useProductList Mock
@@ -26,4 +26,17 @@ const generateList = (): TableItem[] => (
 
 export const useProductList = jest.fn().mockImplementation(() => ({
     list: generateList(),
+}));
+
+// useProductInfo Mock
+const productMock = {
+    description: '<h1>some sample product</h1>',
+    isVisible: true,
+    name: 'Product 1',
+    price: 20,
+    type: 'physical',
+};
+
+export const useProductInfo = jest.fn().mockImplementation(() => ({
+    product: productMock,
 }));

--- a/test/pages/products/__snapshots__/[pid].spec.tsx.snap
+++ b/test/pages/products/__snapshots__/[pid].spec.tsx.snap
@@ -79,7 +79,7 @@ exports[`Product Info Form renders correctly 1`] = `
                     id="bd-select-2-input"
                     name="type"
                     required=""
-                    value=""
+                    value="Physical"
                   />
                 </div>
                 <div
@@ -241,7 +241,9 @@ exports[`Product Info Form renders correctly 1`] = `
             name="description"
             placeholder="Product info"
             rows="3"
-          />
+          >
+            &lt;h1&gt;some sample product&lt;/h1&gt;
+          </textarea>
         </span>
       </div>
     </div>

--- a/types/data.ts
+++ b/types/data.ts
@@ -13,6 +13,10 @@ export interface TableItem {
     stock: number;
 }
 
+export interface ListItem extends FormData {
+    id: number;
+}
+
 export interface StringKeyValue {
     [key: string]: string;
 }


### PR DESCRIPTION
## What?
Fixes an issue when deep linking into products that are not on the first page of products.  Note: this PR still retains the original behavior of first checking if the product is in the cached list.  Now, if the product is not found, it will call the BC API to fetch the product.

This PR includes:
- new, reusable hook `useProductInfo`
- expanded product API endpoint (switches between get and put requests)
- updated product page
- additional test mock for `useProductInfo`

## Why?
To correct a bug (LFG-13)

## Testing / Proof
verified on BigCommerce by installing, loading, and uninstalling the app; confirmed production build and TypeScript by running npm run build, npm run lint, and npm run test
