### PR TITLE
feat(common): LFG-146 - adds multi-store support

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -58,7 +58,7 @@ export async function getSession(req: NextApiRequest) {
         return { ...cookieData, accessToken };
     }
 
-    return await db.getStore();
+    throw new Error('Cookies unavailable. Please reload the application.');
 }
 
 export async function removeSession(res: NextApiResponse, session: SessionProps) {

--- a/lib/dbs/mysql.ts
+++ b/lib/dbs/mysql.ts
@@ -30,31 +30,27 @@ export async function setStore(session: SessionProps) {
 
 // Use setStoreUser for storing store specific variables
 export async function setStoreUser(session: SessionProps) {
-    const { access_token: accessToken, context, user: { id } } = session;
-    if (!id) return null;
+    const { access_token: accessToken, context, user: { id: userId } } = session;
+    if (!userId) return null;
 
     const storeHash = context?.split('/')[1] || '';
-    const [oldAdmin] = await query('SELECT * FROM storeUsers WHERE isAdmin IS TRUE limit 1') ?? [];
+    const sql = 'SELECT * FROM storeUsers WHERE userId = ? AND storeHash = ?';
+    const values = [String(userId), storeHash];
+    const storeUser = await query(sql, values);
 
     // Set admin (store owner) if installing/ updating the app
     // https://developer.bigcommerce.com/api-docs/apps/guide/users
     if (accessToken) {
-        // Nothing to update if admin the same
-        if (oldAdmin?.userId === String(id)) return null;
-
-        // Update admin (if different and previously installed)
-        if (oldAdmin) {
-            await query('UPDATE storeUsers SET isAdmin=0 WHERE isAdmin IS TRUE');
+        // Create a new admin user if none exists
+        if (!storeUser.length) {
+            await query('INSERT INTO storeUsers SET ?', { isAdmin: true, storeHash, userId });
+        } else if (!storeUser[0]?.isAdmin) {
+            await query('UPDATE storeUsers SET isAdmin=1 WHERE userId = ? AND storeHash = ?', values);
         }
-
-        // Create a new record
-        await query('INSERT INTO storeUsers SET ?', { isAdmin: true, storeHash, userId: id });
     } else {
-        const storeUser = await query('SELECT * FROM storeUsers WHERE userId = ?', String(id));
-
         // Create a new user if it doesn't exist (non-store owners added here for multi-user apps)
         if (!storeUser.length) {
-            await query('INSERT INTO storeUsers SET ?', { isAdmin: false, storeHash, userId: id });
+            await query('INSERT INTO storeUsers SET ?', { isAdmin: false, storeHash, userId });
         }
     }
 }
@@ -63,16 +59,10 @@ export async function deleteUser({ user }: SessionProps) {
     await query('DELETE FROM storeUsers WHERE userId = ?', String(user?.id));
 }
 
-export async function getStore() {
-    const results = await query('SELECT * FROM stores limit 1');
-
-    return results.length ? results[0] : null;
-}
-
 export async function getStoreToken(storeHash: string) {
     if (!storeHash) return null;
 
-    const results = await query('SELECT accessToken FROM stores limit 1');
+    const results = await query('SELECT accessToken FROM stores WHERE storeHash = ?', storeHash);
 
     return results.length ? results[0].accessToken : null;
 }

--- a/scripts/db.js
+++ b/scripts/db.js
@@ -27,7 +27,7 @@ const storesCreate = query('CREATE TABLE `stores` (\n' +
 const storeUsersCreate = query('CREATE TABLE `storeUsers` (\n' +
     '  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,\n' +
     '  `userId` int(11) NOT NULL,\n' +
-    '  `storeHash` varchar(10),\n' +
+    '  `storeHash` varchar(10) NOT NULL,\n' +
     '  `isAdmin` boolean,\n' +
     '  PRIMARY KEY (`id`),\n' +
     '  UNIQUE KEY `userId` (`userId`,`storeHash`)\n' +


### PR DESCRIPTION
## What?
Adds support for multiple stores

NOTES:
- This PR changes Firebase's `storeUser` document ID (key) to `userId_storeHash`, instead of just `uid`. This effectively matches mysql unique key (for userId) and allows us to associate multiple stores per user.  The reason we can't just use `uid` is because Firebase requires each document id to be unique, thus there cannot be multiple entries with the same exact id.
- Will squash commits once https://github.com/bigcommerce/sample-app-nodejs/pull/27 is merged

This PR includes:
- refactors DBs to support multiple stores w/ multiple users
- eliminates `getStore` call from both DBs - this function was simply returning the first store in the list. 
- updates auth's `getSession` to rely on cookies - will throw an error if cookies unavailable
- corrects `getStoreToken` in mysql to select based on storeHash (instead of first item)
- modifies Firebase storeUser document ID to `userId`_`storeHash` instead of just uid.  
- ensures storeHash column is not null (for mysql)

## Why?
Required as part of GA

## Testing / Proof
Verified on BigCommerce by installing, loading, and uninstalling the app; confirmed production build and TypeScript by running npm run build, npm run lint, and npm run test.  Additionally, verified changes by deploying app to Heroku and observing SQL DB
