### PR TITLE
fix(common): LFG-222 removes access after logout

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,7 @@
 import * as jwt from 'jsonwebtoken';
-import { NextApiRequest, NextApiResponse } from 'next';
+import { NextApiRequest } from 'next';
 import * as BigCommerce from 'node-bigcommerce';
-import { QueryParams, SessionProps } from '../types';
+import { QueryParams, SessionContextProps, SessionProps } from '../types';
 import db from './db';
 
 const { AUTH_CALLBACK, CLIENT_ID, CLIENT_SECRET, JWT_KEY } = process.env;
@@ -32,11 +32,11 @@ export function bigcommerceClient(accessToken: string, storeHash: string) {
         apiVersion: 'v3'
     });
 }
-
+// Authorizes app on install
 export function getBCAuth(query: QueryParams) {
     return bigcommerce.authorize(query);
 }
-
+// Verifies app on load/ uninstall
 export function getBCVerify({ signed_payload }: QueryParams) {
     return bigcommerceSigned.verify(signed_payload);
 }
@@ -51,30 +51,41 @@ export async function getSession({ query: { context = '' } }: NextApiRequest) {
     if (typeof context !== 'string') return;
     const { context: storeHash, user } = decodePayload(context);
     const hasUser = await db.hasStoreUser(storeHash, user?.id);
-    const accessToken = await db.getStoreToken(storeHash);
 
     // Before retrieving session/ hitting APIs, check user
     if (!hasUser) {
         throw new Error('User is not available. Please login or ensure you have access permissions.');
     }
 
-    return { accessToken, storeHash };
+    const accessToken = await db.getStoreToken(storeHash);
+
+    return { accessToken, storeHash, user };
 }
 
-export async function removeSession(res: NextApiResponse, session: SessionProps) {
-    await db.deleteStore(session);
-}
-
-export async function removeUserData(res: NextApiResponse, session: SessionProps) {
-    await db.deleteUser(session);
-}
-
+// JWT functions to sign/ verify 'context' query param from /api/auth||load
 export function encodePayload({ user, owner, ...session }: SessionProps) {
     const context = session?.context?.split('/')[1] || '';
 
     return jwt.sign({ context, user, owner }, JWT_KEY, { expiresIn: '24h' });
 }
-
+// Verifies JWT for getSession (product APIs)
 export function decodePayload(encodedContext: string) {
     return jwt.verify(encodedContext, JWT_KEY);
+}
+
+// Removes store and storeUser on uninstall
+export async function removeDataStore(session: SessionProps) {
+    await db.deleteStore(session);
+    await db.deleteUser(session);
+}
+
+// Removes users from app - getSession() for user will fail after user is removed
+export async function removeUserData(session: SessionProps) {
+    await db.deleteUser(session);
+}
+
+// Removes user from storeUsers on logout
+export async function logoutUser({ storeHash, user }: SessionContextProps) {
+    const session = { context: `store/${storeHash}`, user };
+    await db.deleteUser(session);
 }

--- a/lib/dbs/firebase.ts
+++ b/lib/dbs/firebase.ts
@@ -53,7 +53,7 @@ export async function setStore(session: SessionProps) {
 // User management for multi-user apps
 // Use setStoreUser for storing store specific variables
 export async function setStoreUser(session: SessionProps) {
-    const { access_token: accessToken, context, user: { id: userId } } = session;
+    const { access_token: accessToken, context, owner, user: { id: userId } } = session;
     if (!userId) return null;
 
     const storeHash = context?.split('/')[1] || '';
@@ -72,9 +72,9 @@ export async function setStoreUser(session: SessionProps) {
             await ref.update({ isAdmin: true });
         }
     } else {
-        // Create a new user if it doesn't exist (non-store owners added here for multi-user apps)
+        // Create a new user if it doesn't exist
         if (!storeUser?.exists) {
-            await ref.set({ storeHash, isAdmin: false });
+            await ref.set({ storeHash, isAdmin: owner.id === userId }); // isAdmin true if owner == user
         }
     }
 }

--- a/lib/dbs/mysql.ts
+++ b/lib/dbs/mysql.ts
@@ -30,7 +30,7 @@ export async function setStore(session: SessionProps) {
 
 // Use setStoreUser for storing store specific variables
 export async function setStoreUser(session: SessionProps) {
-    const { access_token: accessToken, context, user: { id: userId } } = session;
+    const { access_token: accessToken, context, owner, user: { id: userId } } = session;
     if (!userId) return null;
 
     const storeHash = context?.split('/')[1] || '';
@@ -50,7 +50,7 @@ export async function setStoreUser(session: SessionProps) {
     } else {
         // Create a new user if it doesn't exist (non-store owners added here for multi-user apps)
         if (!storeUser.length) {
-            await query('INSERT INTO storeUsers SET ?', { isAdmin: false, storeHash, userId });
+            await query('INSERT INTO storeUsers SET ?', { isAdmin: owner.id === userId, storeHash, userId });
         }
     }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,15 +1,19 @@
 import { Box, GlobalStyles } from '@bigcommerce/big-design';
 import type { AppProps } from 'next/app';
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import Header from '../components/header';
 import SessionProvider from '../context/session';
 import { bigCommerceSDK } from '../scripts/bcSdk';
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
+    const router = useRouter();
+    const { query: { context } } = router;
+
     useEffect(() => {
         // Keeps app in sync with BC (e.g. heatbeat, user logout, etc)
-        bigCommerceSDK();
-    }, []); // Run once during mounting
+        if (context) bigCommerceSDK(context);
+    }, [context]);
 
     return (
         <>

--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -1,0 +1,14 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getSession, logoutUser } from '../../lib/auth';
+
+export default async function logout(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const session = await getSession(req);
+
+        await logoutUser(session);
+        res.status(200).end();
+    } catch (error) {
+        const { message, response } = error;
+        res.status(response?.status || 500).json({ message });
+    }
+}

--- a/pages/api/removeUser.ts
+++ b/pages/api/removeUser.ts
@@ -5,7 +5,7 @@ export default async function removeUser(req: NextApiRequest, res: NextApiRespon
     try {
         const session = await getBCVerify(req.query);
 
-        await removeUserData(res, session);
+        await removeUserData(session);
         res.status(200).end();
     } catch (error) {
         const { message, response } = error;

--- a/pages/api/uninstall.ts
+++ b/pages/api/uninstall.ts
@@ -1,11 +1,11 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { getBCVerify, removeSession } from '../../lib/auth';
+import { getBCVerify, removeDataStore } from '../../lib/auth';
 
 export default async function uninstall(req: NextApiRequest, res: NextApiResponse) {
     try {
         const session = await getBCVerify(req.query);
 
-        await removeSession(res, session);
+        await removeDataStore(session);
         res.status(200).end();
     } catch (error) {
         const { message, response } = error;

--- a/scripts/bcSdk.js
+++ b/scripts/bcSdk.js
@@ -1,4 +1,4 @@
-export function bigCommerceSDK() {
+export function bigCommerceSDK(context) {
     if (typeof window === "undefined") return;
 
     const s = 'script';
@@ -15,6 +15,10 @@ export function bigCommerceSDK() {
     bcjs.parentNode.insertBefore(js, bcjs);
 
     window.bcAsyncInit = function() {
-        Bigcommerce.init();
+        Bigcommerce.init({
+            onLogout: function() {
+                fetch(`/api/logout?context=${context}`);
+            },
+        });
     }
 }

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -7,10 +7,16 @@ export interface User {
 export interface SessionProps {
     access_token?: string;
     context: string;
-    owner: User;
+    owner?: User;
     scope?: string;
     store_hash?: string;
     timestamp?: number;
+    user: User;
+}
+
+export interface SessionContextProps {
+    accessToken: string;
+    storeHash: string;
     user: User;
 }
 


### PR DESCRIPTION
## What?
Fixes a security vulnerability whereby a user could still access the app after logging out in the CP.  Effectively, this PR adds a new `logout` API and syncs the CP logout with the BC SDK.

Warning when logged out:
![Screen Shot 2021-06-30 at 11 25 04 AM](https://user-images.githubusercontent.com/38708175/124040409-ba238800-d9b9-11eb-8ed3-49bf09678d3f.png)


## Why?
Security vulnerability 

## Testing / Proof
Verified on BigCommerce by installing, loading, and uninstalling the app; established production build and TypeScript by running npm run build. Linting and unit tests also ran. All API endpoints also verified.

@bigcommerce/api-client-developers
