### PR TITLE
fix(common): LFG-220 Fix is_visible product flag not being set via api

### DIFF
--- a/pages/products/[pid].tsx
+++ b/pages/products/[pid].tsx
@@ -20,6 +20,9 @@ const ProductInfo = () => {
     const handleSubmit = async (data: FormData) => {
         try {
             const filteredList = list.filter(item => item.id !== pid);
+            const { description, isVisible, name, price, type } = data;
+            const apiFormattedData = { description, is_visible: isVisible, name, price, type };
+
             // Update local data immediately (reduce latency to user)
             mutateList([...filteredList, { ...product, ...data }], false);
 
@@ -27,7 +30,7 @@ const ProductInfo = () => {
             await fetch(`/api/products/${pid}?context=${encodedContext}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
+                body: JSON.stringify(apiFormattedData),
             });
 
             // Refetch to validate local data


### PR DESCRIPTION
## What?
Fixes the PUT api call when updating products to that `isVisible` is correctly transformed to `is_visible` as the API requires.

## Why?
This flag was not being set correctly when updating products.

## Testing / Proof
Tested by verifying product update functionality via a heroku deployment of the app. Tests and linting ran successfully.

@bigcommerce/api-client-developers
