### PR TITLE
fix(common): persistant session across pages

### DIFF
--- a/context/session.tsx
+++ b/context/session.tsx
@@ -1,14 +1,23 @@
-import { createContext, useContext, useState } from 'react';
-import { ContextValues } from '../types';
+import { useRouter } from 'next/router';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { bigCommerceSDK } from '../scripts/bcSdk';
 
-const SessionContext = createContext<Partial<ContextValues>>({});
+const SessionContext = createContext({ context: '' });
 
 const SessionProvider = ({ children }) => {
+    const { query } = useRouter();
     const [context, setContext] = useState('');
-    const value = { context, setContext };
+
+    useEffect(() => {
+        if (query.context) {
+            setContext(query.context.toString());
+            // Keeps app in sync with BC (e.g. heatbeat, user logout, etc)
+            bigCommerceSDK(query.context);
+        }
+    }, [query.context]);
 
     return (
-        <SessionContext.Provider value={value}>
+        <SessionContext.Provider value={{ context }}>
             {children}
         </SessionContext.Provider>
     );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,20 +1,9 @@
 import { Box, GlobalStyles } from '@bigcommerce/big-design';
 import type { AppProps } from 'next/app';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 import Header from '../components/header';
 import SessionProvider from '../context/session';
-import { bigCommerceSDK } from '../scripts/bcSdk';
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
-    const router = useRouter();
-    const { query: { context } } = router;
-
-    useEffect(() => {
-        // Keeps app in sync with BC (e.g. heatbeat, user logout, etc)
-        if (context) bigCommerceSDK(context);
-    }, [context]);
-
     return (
         <>
             <GlobalStyles />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,18 +1,11 @@
 import { Box, Flex, H1, H4, Panel } from '@bigcommerce/big-design';
-import { useEffect } from 'react';
 import styled from 'styled-components';
 import ErrorMessage from '../components/error';
 import Loading from '../components/loading';
-import { useSession } from '../context/session';
 import { useProducts } from '../lib/hooks';
 
-const Index = ({ context }: { context: string }) => {
+const Index = () => {
     const { error, isLoading, summary } = useProducts();
-    const { setContext } = useSession();
-
-    useEffect(() => {
-        if (context) setContext(context);
-    }, [context, setContext]);
 
     if (isLoading) return <Loading />;
     if (error) return <ErrorMessage error={error} />;
@@ -36,10 +29,6 @@ const Index = ({ context }: { context: string }) => {
         </Panel>
     );
 };
-
-export const getServerSideProps = async ({ query }) => ({
-    props: { context: query?.context ?? '' }
-});
 
 const StyledBox = styled(Box)`
     min-width: 10rem;

--- a/types/data.ts
+++ b/types/data.ts
@@ -1,8 +1,3 @@
-export interface ContextValues {
-  context: string;
-  setContext: (key: string) => void;
-}
-
 export interface FormData {
     description: string;
     isVisible: boolean;


### PR DESCRIPTION
## What?
Creates a better persistence of session across all pages.

## Why?
If we end up loading the app on the `/products` page, we'll get the context from the load URL and pass it into the session context.

@bigcommerce/api-client-developers
