### PR TITLE
feat(common): use jwt url value for load redirect

### DIFF
--- a/pages/api/load.ts
+++ b/pages/api/load.ts
@@ -1,6 +1,13 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { encodePayload, getBCVerify, setSession } from '../../lib/auth';
 
+const buildRedirectUrl = (url: string, encodedContext: string) => {
+    const [path, query = ''] = url.split('?');
+    const queryParams = new URLSearchParams(`context=${encodedContext}&${query}`);
+
+    return `${path}?${queryParams}`;
+}
+
 export default async function load(req: NextApiRequest, res: NextApiResponse) {
     try {
         // Verify when app loaded (launch)
@@ -8,7 +15,7 @@ export default async function load(req: NextApiRequest, res: NextApiResponse) {
         const encodedContext = encodePayload(session); // Signed JWT to validate/ prevent tampering
 
         await setSession(session);
-        res.redirect(302, `/?context=${encodedContext}`);
+        res.redirect(302, buildRedirectUrl(session.url, encodedContext));
     } catch (error) {
         const { message, response } = error;
         res.status(response?.status || 500).json({ message });


### PR DESCRIPTION
## What?
Use the JWT token `url` key/value to load redirect URL.

## Why?
This allows paths to be provided when the app loads. For instance, we want to load `/app/6/orders/100?foo=1&bar=2` the app will now be able to redirect to `/orders/100?context=<encodedContext>&foo=1&bar=2`.

## Testing / Proof
Params passed into the app:
<img width="407" alt="Screen Shot 2021-11-05 at 11 27 15" src="https://user-images.githubusercontent.com/10539418/140544874-55f81317-310c-46a4-9cfb-c1d57869a924.png">

@bigcommerce/api-client-developers
