### PR TITLE
feat(common): add ThemeProvider to _app.tsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -802,6 +802,17 @@
         "react-datepicker": "^2.16.0",
         "react-popper": "^2.2.3",
         "react-uid": "^2.2.0"
+      },
+      "dependencies": {
+        "@bigcommerce/big-design-theme": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@bigcommerce/big-design-theme/-/big-design-theme-0.11.0.tgz",
+          "integrity": "sha512-w3XlarLnddQgadQ99Q+ZhHTVMEdUzchZ44XKFKHiIy3gIEatXLXei/09telIrHJA1HALMpCMeqswKikMVPbdkg==",
+          "requires": {
+            "@babel/runtime": "^7.12.1",
+            "polished": "^3.0.3"
+          }
+        }
       }
     },
     "@bigcommerce/big-design-icons": {
@@ -812,12 +823,23 @@
         "@babel/runtime": "^7.12.1",
         "@bigcommerce/big-design-theme": "^0.11.0",
         "react-uid": "^2.2.0"
+      },
+      "dependencies": {
+        "@bigcommerce/big-design-theme": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@bigcommerce/big-design-theme/-/big-design-theme-0.11.0.tgz",
+          "integrity": "sha512-w3XlarLnddQgadQ99Q+ZhHTVMEdUzchZ44XKFKHiIy3gIEatXLXei/09telIrHJA1HALMpCMeqswKikMVPbdkg==",
+          "requires": {
+            "@babel/runtime": "^7.12.1",
+            "polished": "^3.0.3"
+          }
+        }
       }
     },
     "@bigcommerce/big-design-theme": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/big-design-theme/-/big-design-theme-0.11.0.tgz",
-      "integrity": "sha512-w3XlarLnddQgadQ99Q+ZhHTVMEdUzchZ44XKFKHiIy3gIEatXLXei/09telIrHJA1HALMpCMeqswKikMVPbdkg==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/big-design-theme/-/big-design-theme-0.13.1.tgz",
+      "integrity": "sha512-om29M9O3KtgwCloUUQYaH6RXW816x3drAEuSX0uaYwDRVSNkG0SWz5grXBTsel+FtvNhG4vsjU01a/6ELvBiUA==",
       "requires": {
         "@babel/runtime": "^7.12.1",
         "polished": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@bigcommerce/big-design": "^0.27.0",
+    "@bigcommerce/big-design-theme": "^0.13.1",
     "firebase": "^8.2.6",
     "jsonwebtoken": "^8.5.1",
     "mysql": "^2.18.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,13 @@
 import { Box, GlobalStyles } from '@bigcommerce/big-design';
+import { theme as defaultTheme } from '@bigcommerce/big-design-theme';
 import type { AppProps } from 'next/app';
+import { ThemeProvider } from 'styled-components';
 import Header from '../components/header';
 import SessionProvider from '../context/session';
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
     return (
-        <>
+        <ThemeProvider theme={defaultTheme}>
             <GlobalStyles />
             <Box marginHorizontal="xxxLarge" marginVertical="xxLarge">
                 <Header />
@@ -13,7 +15,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
                     <Component {...pageProps} />
                 </SessionProvider>
             </Box>
-        </>
+        </ThemeProvider>
     );
 };
 


### PR DESCRIPTION
## What?
Adds a `ThemeProvider` to the application.

## Why?
Provides a way to use the theme when building styled-components.

For example,

```tsx
import styled from 'styled-components';

const StyledDl = styled.dl`
  color: ${({ theme }) => theme.colors.secondary70};
  line-height: ${({ theme }) => theme.lineHeight.medium};
`;
```
