### PR TITLE
feat(common): APPEX-204 add api support for testing

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,10 +1,17 @@
 import * as jwt from 'jsonwebtoken';
 import { NextApiRequest } from 'next';
 import * as BigCommerce from 'node-bigcommerce';
-import { QueryParams, SessionContextProps, SessionProps } from '../types';
+import { ApiConfig, QueryParams, SessionContextProps, SessionProps } from '../types';
 import db from './db';
 
-const { AUTH_CALLBACK, CLIENT_ID, CLIENT_SECRET, JWT_KEY } = process.env;
+const { API_URL, AUTH_CALLBACK, CLIENT_ID, CLIENT_SECRET, JWT_KEY, LOGIN_URL } = process.env;
+
+// Used for internal configuration; 3rd party apps may remove
+const apiConfig: ApiConfig = {};
+if (API_URL && LOGIN_URL) {
+    apiConfig.apiUrl = API_URL;
+    apiConfig.loginUrl = LOGIN_URL;
+}
 
 // Create BigCommerce instance
 // https://github.com/bigcommerce/node-bigcommerce/
@@ -16,6 +23,7 @@ const bigcommerce = new BigCommerce({
     responseType: 'json',
     headers: { 'Accept-Encoding': '*' },
     apiVersion: 'v3',
+    ...apiConfig,
 });
 
 const bigcommerceSigned = new BigCommerce({
@@ -30,6 +38,7 @@ export function bigcommerceClient(accessToken: string, storeHash: string, apiVer
         storeHash,
         responseType: 'json',
         apiVersion,
+        ...apiConfig,
     });
 }
 

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -24,3 +24,8 @@ export interface SessionContextProps {
 export interface QueryParams {
     [key: string]: string | string[];
 }
+
+export interface ApiConfig {
+    apiUrl?: string;
+    loginUrl?: string;
+}


### PR DESCRIPTION
## What?
Adds support for testing in different environments. Note: we cannot rely on `process.env.NODE_ENV` as `next start` will return 'production.'

## Why?
We need to be able to utilize testing api hosts on non-production targets.

## Testing / Proof
Verified by installing/ loading the app, linting, established production build and TypeScript by running npm run build.

@bigcommerce/api-client-developers
