### PR TITLE
fix(common): APPEX-279 delete all store users on uninstall

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -84,10 +84,10 @@ export function decodePayload(encodedContext: string) {
     return jwt.verify(encodedContext, JWT_KEY);
 }
 
-// Removes store and storeUser on uninstall
+// Removes store and storeUsers on uninstall
 export async function removeDataStore(session: SessionProps) {
     await db.deleteStore(session);
-    await db.deleteUser(session);
+    await db.deleteStoreUsers(session);
 }
 
 // Removes users from app - getSession() for user will fail after user is removed

--- a/lib/dbs/mysql.ts
+++ b/lib/dbs/mysql.ts
@@ -71,6 +71,12 @@ export async function deleteUser({ context, user, sub }: SessionProps) {
     await query('DELETE FROM storeUsers WHERE userId = ? AND storeHash = ?', values);
 }
 
+export async function deleteStoreUsers({ context, sub }: SessionProps) {
+    const contextString = context ?? sub;
+    const storeHash = contextString?.split('/')[1] || '';
+    await query('DELETE FROM storeUsers WHERE storeHash = ?', storeHash);
+}
+
 export async function hasStoreUser(storeHash: string, userId: string) {
     if (!storeHash || !userId) return false;
 
@@ -88,6 +94,8 @@ export async function getStoreToken(storeHash: string) {
     return results.length ? results[0].accessToken : null;
 }
 
-export async function deleteStore({ store_hash: storeHash }: SessionProps) {
+export async function deleteStore({ context, sub }: SessionProps) {
+    const contextString = context ?? sub;
+    const storeHash = contextString?.split('/')[1] || '';
     await query('DELETE FROM stores WHERE storeHash = ?', storeHash);
 }

--- a/types/db.ts
+++ b/types/db.ts
@@ -20,4 +20,5 @@ export interface Db {
     getStoreToken(storeId: string): string | null;
     deleteStore(session: SessionProps): Promise<void>;
     deleteUser(session: SessionProps): Promise<void>;
+    deleteStoreUsers(session: SessionProps): Promise<void>;
 }


### PR DESCRIPTION
## What?
- Adds `deleteStoreUsers` method to both firebase and mysql modules to be called from `removeDataStore` on uninstall. - - Fixes `deleteStore` method.

## Why?
[APPEX-279](https://bigcommercecloud.atlassian.net/browse/APPEX-279)
...

## Testing / Proof
Verified manually for both Firebase and MySQL.
...

@bigcommerce/api-client-developers
