### PR TITLE
fix(common): fix welcome alert

### DIFF
--- a/pages/api/checkout/removeWelcome.ts
+++ b/pages/api/checkout/removeWelcome.ts
@@ -4,7 +4,10 @@ import { getSession, setWelcome } from '../../../lib/auth';
 export default async function removeWelcome(req: NextApiRequest, res: NextApiResponse) {
     try {
         const { storeHash } = await getSession(req);
-        setWelcome(storeHash, false);
+
+        setTimeout(() => {
+            setWelcome(storeHash, false);
+        }, 1000);
 
         res.status(200).json({});
     } catch (error) {


### PR DESCRIPTION
## What?
Noticed a bug while demoing - the welcome alert may not show if the iframe temporarily shows a duplicate frame when redirecting back to the app. 

## Why?
Welcome alert not displaying

## Testing / Proof
locally and on staging, verified build and test passing

@bigcommerce/api-client-developers
