### PR TITLE
fix(common): APPEX-448 updates docs links in README step 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get the app running locally, follow these instructions:
 3. [Add and start ngrok.](https://www.npmjs.com/package/ngrok#usage) Note: use port 3000 to match Next's server.
     - `npm install ngrok`
     - `ngrok http 3000`
-4. [Register a draft app.](https://developer.bigcommerce.com/api-docs/apps/quick-start#register-a-draft-app)
+4. [Register a draft app.](https://developer.bigcommerce.com/docs/3ef776e175eda-big-commerce-apps-quick-start#register-the-app)
      - For steps 5-7, enter callbacks as `'https://{ngrok_id}.ngrok.io/api/{auth||load||uninstall}'`. 
      - Get `ngrok_id` from the terminal that's running `ngrok http 3000`.
      - e.g. auth callback: `https://12345.ngrok.io/api/auth`
@@ -21,4 +21,4 @@ To get the app running locally, follow these instructions:
 7. Update AUTH_CALLBACK in `.env` with the `ngrok_id` from step 5.
 8. Start your dev environment in a **separate** terminal from `ngrok`. If `ngrok` restarts, update callbacks in steps 4 and 7 with the new ngrok_id.
     - `npm run dev`
-9. [Install the app and launch.](https://developer.bigcommerce.com/api-docs/apps/quick-start#install-the-app)
+9. [Install the app and launch.](https://developer.bigcommerce.com/docs/3ef776e175eda-big-commerce-apps-quick-start#install-the-app)


### PR DESCRIPTION
## What?
Updates links to Sample App quickstart guide in the docs.

## Why?
Broken links from docs update

## Testing / Proof
...

@bigcommerce/api-client-developers
