### PR TITLE
feat(appext): APPEX-359 Add refernce example using App Extensions

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -17,6 +17,7 @@ const HeaderlessRoutes = [
     '/orders/[orderId]',
     '/orders/[orderId]/labels',
     '/orders/[orderId]/modal',
+    '/product/[productId]',
 ];
 
 const InnerRoutes = [

--- a/pages/product/[productId]/index.tsx
+++ b/pages/product/[productId]/index.tsx
@@ -1,0 +1,47 @@
+import { Panel, Text } from "@bigcommerce/big-design";
+import { useRouter } from "next/router";
+import ErrorMessage from "@components/error";
+import Loading from "@components/loading";
+import { useProductInfo, useProductList } from "@lib/hooks";
+
+const SidePanel = () => {
+  const router = useRouter();
+  const productId = Number(router.query?.productId);
+  const { error, isLoading, list = [] } = useProductList();
+  const { isLoading: isInfoLoading, product } = useProductInfo(productId, list);
+  const {
+    description,
+    is_visible: isVisible,
+    name,
+    price,
+    type,
+  } = product ?? {};
+  const panelData = { description, isVisible, name, price, type };
+
+  const capitalizeFirst = (str: string) => {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  };
+
+  if (isLoading || isInfoLoading) return <Loading />;
+  if (error) return <ErrorMessage error={error} />;
+
+  return (
+    <>
+      <Panel header="Basic Information">
+        <Text bold>Product name</Text>
+        <p>{panelData.name}</p>
+        <Text bold>Product type</Text>
+        <p>{capitalizeFirst(panelData.type)}</p>
+        <Text bold>Default price (excluding tax)</Text>
+        <p>$ {panelData.price}</p>
+        <p>{panelData.isVisible}</p>
+      </Panel>
+      <Panel header="Description">
+        <Text bold>Description</Text>
+        <p>{panelData.description}</p>
+      </Panel>
+    </>
+  );
+};
+
+export default SidePanel;

--- a/test/pages/__snapshots__/index.spec.tsx.snap
+++ b/test/pages/__snapshots__/index.spec.tsx.snap
@@ -2,59 +2,59 @@
 
 exports[`Homepage renders correctly 1`] = `
 <div
-  class="styled__StyledBox-sc-sj5f1m-0 cmToHM styled__StyledPanel-sc-1h6ef3q-0 dJwQJf"
+  class="styled__StyledBox-sc-sj5f1m-0 odkmb styled__StyledPanel-sc-1h6ef3q-0 gyZFEm"
   id="home"
 >
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlex-sc-hcvk8l-0 fzBpqP"
+    class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 hPcIGA"
   >
     <h2
-      class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 fVcMKm bJUVLc"
+      class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 kEGvNd fjdBDH"
     >
       Homepage
     </h2>
   </div>
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlex-sc-hcvk8l-0 fiKrzl"
+    class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iYaJla"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 llWHkN pages__StyledBox-sc-jwwna7-0 dwmNpl"
+      class="styled__StyledBox-sc-sj5f1m-0 hdrjpG pages__StyledBox-sc-jwwna7-0 kfGRKK"
     >
       <h4
-        class="styled__StyledH4-sc-tqnj75-4 bnFDUS"
+        class="styled__StyledH4-sc-tqnj75-4 XRfzZ"
       >
         Inventory count
       </h4>
       <h1
-        class="styled__StyledH1-sc-tqnj75-1 fcbrov"
+        class="styled__StyledH1-sc-tqnj75-1 hetgrk"
       >
         3
       </h1>
     </div>
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 llWHkN pages__StyledBox-sc-jwwna7-0 dwmNpl"
+      class="styled__StyledBox-sc-sj5f1m-0 hdrjpG pages__StyledBox-sc-jwwna7-0 kfGRKK"
     >
       <h4
-        class="styled__StyledH4-sc-tqnj75-4 bnFDUS"
+        class="styled__StyledH4-sc-tqnj75-4 XRfzZ"
       >
         Variant count
       </h4>
       <h1
-        class="styled__StyledH1-sc-tqnj75-1 fcbrov"
+        class="styled__StyledH1-sc-tqnj75-1 hetgrk"
       >
         2
       </h1>
     </div>
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 ffxnyT pages__StyledBox-sc-jwwna7-0 dwmNpl"
+      class="styled__StyledBox-sc-sj5f1m-0 bNGvkM pages__StyledBox-sc-jwwna7-0 kfGRKK"
     >
       <h4
-        class="styled__StyledH4-sc-tqnj75-4 bnFDUS"
+        class="styled__StyledH4-sc-tqnj75-4 XRfzZ"
       >
         Primary category
       </h4>
       <h1
-        class="styled__StyledH1-sc-tqnj75-1 fcbrov"
+        class="styled__StyledH1-sc-tqnj75-1 hetgrk"
       >
         widgets
       </h1>

--- a/test/pages/product/__snapshots__/index.spec.tsx.snap
+++ b/test/pages/product/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SidePanel renders correctly 1`] = `
+<div
+  class="styled__StyledBox-sc-sj5f1m-0 odkmb styled__StyledPanel-sc-1h6ef3q-0 gyZFEm"
+>
+  <div
+    class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 hPcIGA"
+  >
+    <h2
+      class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 kEGvNd fjdBDH"
+    >
+      Basic Information
+    </h2>
+  </div>
+  <p
+    class="styled__StyledText-sc-tqnj75-5 dBDsjF"
+  >
+    Product name
+  </p>
+  <p>
+    Product 1
+  </p>
+  <p
+    class="styled__StyledText-sc-tqnj75-5 dBDsjF"
+  >
+    Product type
+  </p>
+  <p>
+    Physical
+  </p>
+  <p
+    class="styled__StyledText-sc-tqnj75-5 dBDsjF"
+  >
+    Default price (excluding tax)
+  </p>
+  <p>
+    $ 
+    20
+  </p>
+  <p />
+</div>
+`;

--- a/test/pages/product/index.spec.tsx
+++ b/test/pages/product/index.spec.tsx
@@ -1,0 +1,22 @@
+import { useRouter } from "next/router";
+import SidePanel from "@pages/product/[productId]"; 
+import { render, screen} from '@test/utils';
+
+jest.mock('@lib/hooks', () => require('@mocks/hooks'));
+jest.mock('next/router', () => ({
+    useRouter: jest.fn(),
+}));
+
+describe('SidePanel', () => {
+    const router = { query: { pid: '1' } };
+    useRouter.mockReturnValue(router);
+
+    test('renders correctly', async () => {
+        const { container } = render(<SidePanel />);
+        // Wait for table to be rendered
+        screen.getByText('Basic Information');
+
+        expect(container.firstChild).toMatchSnapshot();
+    });
+});
+

--- a/test/pages/products/__snapshots__/[pid].spec.tsx.snap
+++ b/test/pages/products/__snapshots__/[pid].spec.tsx.snap
@@ -2,38 +2,38 @@
 
 exports[`Product Info Form renders correctly 1`] = `
 <form
-  class="styled__StyledForm-sc-qzey9b-0 fmYsJy"
+  class="styled__StyledForm-sc-qzey9b-0 haqnpB"
 >
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 cmToHM styled__StyledPanel-sc-1h6ef3q-0 dJwQJf"
+    class="styled__StyledBox-sc-sj5f1m-0 odkmb styled__StyledPanel-sc-1h6ef3q-0 gyZFEm"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlex-sc-hcvk8l-0 fzBpqP"
+      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 hPcIGA"
     >
       <h2
-        class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 fVcMKm bJUVLc"
+        class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 kEGvNd fjdBDH"
       >
         Basic Information
       </h2>
     </div>
     <div
-      class="styled__StyledInlineGroup-sc-1a6yr6l-2 eLuDxx"
+      class="styled__StyledInlineGroup-sc-1a6yr6l-2 jiJxde"
     >
       <div>
         <label
-          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 bnFDUS fmZQLZ"
+          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 XRfzZ cgVpUS"
           for="bd-input-1"
         >
           Product name
         </label>
         <span
-          class="styled__StyledInputWrapper-sc-g32raa-0 juaxtU"
+          class="styled__StyledInputWrapper-sc-g32raa-0 kqLUdD"
         >
           <div
-            class="styled__StyledInputContent-sc-g32raa-3 dZzaFZ"
+            class="styled__StyledInputContent-sc-g32raa-3 gSfFFG"
           >
             <input
-              class="styled__StyledInput-sc-g32raa-1 gTvaKu"
+              class="styled__StyledInput-sc-g32raa-1 cYyall"
               id="bd-input-1"
               name="name"
               required=""
@@ -44,11 +44,11 @@ exports[`Product Info Form renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="styled__StyledInlineGroup-sc-1a6yr6l-2 eLuDxx"
+      class="styled__StyledInlineGroup-sc-1a6yr6l-2 jiJxde"
     >
       <div>
         <label
-          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 bnFDUS fmZQLZ"
+          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 XRfzZ cgVpUS"
           for="bd-select-2-input"
           id="bd-select-2-label"
         >
@@ -61,21 +61,21 @@ exports[`Product Info Form renders correctly 1`] = `
           role="combobox"
         >
           <div
-            class="styled__StyledInputContainer-sc-1v66t78-2 gTYyTJ"
+            class="styled__StyledInputContainer-sc-1v66t78-2 cwtBIS"
           >
             <div>
               <span
-                class="styled__StyledInputWrapper-sc-g32raa-0 juaxtU"
+                class="styled__StyledInputWrapper-sc-g32raa-0 kqLUdD"
               >
                 <div
-                  class="styled__StyledInputContent-sc-g32raa-3 dZzaFZ"
+                  class="styled__StyledInputContent-sc-g32raa-3 gSfFFG"
                 >
                   <input
                     aria-autocomplete="list"
                     aria-controls="bd-select-2-menu"
                     aria-labelledby="bd-select-2-label"
                     autocomplete="off"
-                    class="styled__StyledInput-sc-g32raa-1 jcMnOi"
+                    class="styled__StyledInput-sc-g32raa-1 bWoXXx"
                     id="bd-select-2-input"
                     name="type"
                     required=""
@@ -83,21 +83,21 @@ exports[`Product Info Form renders correctly 1`] = `
                   />
                 </div>
                 <div
-                  class="styled__StyledIconWrapper-sc-g32raa-2 kwPgYS"
+                  class="styled__StyledIconWrapper-sc-g32raa-2 jnYXyh"
                 >
                   <button
                     aria-label="toggle menu"
-                    class="styled__StyledButton-sc-3yq204-0 fvlRpk styled__DropdownButton-sc-1v66t78-3 dYEhdB"
+                    class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__DropdownButton-sc-1v66t78-3 fhvqti"
                     id="bd-select-2-toggle-button"
                     tabindex="-1"
                     type="button"
                   >
                     <span
-                      class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+                      class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
                     >
                       <svg
                         aria-hidden="true"
-                        class="base__StyledIcon-sc-a9u0e1-0 fLZzZV styled__StyledDropdownIcon-sc-1v66t78-1 clpwcN"
+                        class="base__StyledIcon-sc-a9u0e1-0 bwFIuO styled__StyledDropdownIcon-sc-1v66t78-1 erQgzy"
                         fill="currentColor"
                         height="24"
                         stroke="currentColor"
@@ -121,12 +121,12 @@ exports[`Product Info Form renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 jZjBTX"
+          class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
           style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
         >
           <ul
             aria-labelledby="bd-select-2-label"
-            class="styled__StyledList-sc-5w3dcq-0 iPQrcI"
+            class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
             id="bd-select-2-menu"
             role="listbox"
           />
@@ -134,28 +134,28 @@ exports[`Product Info Form renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="styled__StyledInlineGroup-sc-1a6yr6l-2 eLuDxx"
+      class="styled__StyledInlineGroup-sc-1a6yr6l-2 jiJxde"
     >
       <div>
         <label
-          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 bnFDUS fmZQLZ"
+          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 XRfzZ cgVpUS"
           for="bd-input-5"
         >
           Default price (excluding tax)
         </label>
         <span
-          class="styled__StyledInputWrapper-sc-g32raa-0 juaxtU"
+          class="styled__StyledInputWrapper-sc-g32raa-0 kqLUdD"
         >
           <div
-            class="styled__StyledIconWrapper-sc-g32raa-2 ilhexJ"
+            class="styled__StyledIconWrapper-sc-g32raa-2 iEguxa"
           >
             $
           </div>
           <div
-            class="styled__StyledInputContent-sc-g32raa-3 dZzaFZ"
+            class="styled__StyledInputContent-sc-g32raa-3 gSfFFG"
           >
             <input
-              class="styled__StyledInput-sc-g32raa-1 GoTCd"
+              class="styled__StyledInput-sc-g32raa-1 iEJsoi"
               id="bd-input-5"
               name="price"
               placeholder="10.00"
@@ -169,26 +169,26 @@ exports[`Product Info Form renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="styled__StyledGroup-sc-1a6yr6l-1 erKyZH"
+      class="styled__StyledGroup-sc-1a6yr6l-1 cipyTA"
     >
       <div
-        class="styled__CheckboxContainer-sc-s1u0st-1 BPzxd"
+        class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
       >
         <input
           aria-labelledby="bd-checkbox_label-7"
-          class="styled__HiddenCheckbox-sc-s1u0st-2 fOezJh"
+          class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
           id="bd-checkbox-6"
           name="isVisible"
           type="checkbox"
         />
         <label
           aria-hidden="true"
-          class="styled__StyledCheckbox-sc-s1u0st-3 eeOlTF"
+          class="styled__StyledCheckbox-sc-s1u0st-3 Brufm"
           for="bd-checkbox-6"
         >
           <svg
             aria-hidden="true"
-            class="base__StyledIcon-sc-a9u0e1-0 fLZzZV"
+            class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
             fill="currentColor"
             height="24"
             stroke="currentColor"
@@ -206,10 +206,10 @@ exports[`Product Info Form renders correctly 1`] = `
           </svg>
         </label>
         <div
-          class="styled__CheckboxLabelContainer-sc-s1u0st-0 ikhfic"
+          class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
         >
           <label
-            class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 hkcwGz bgPwZa"
+            class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk hcVtt"
             for="bd-checkbox-6"
             id="bd-checkbox_label-7"
           >
@@ -220,32 +220,32 @@ exports[`Product Info Form renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 cmToHM styled__StyledPanel-sc-1h6ef3q-0 dJwQJf"
+    class="styled__StyledBox-sc-sj5f1m-0 odkmb styled__StyledPanel-sc-1h6ef3q-0 gyZFEm"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlex-sc-hcvk8l-0 fzBpqP"
+      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 hPcIGA"
     >
       <h2
-        class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 fVcMKm bJUVLc"
+        class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 kEGvNd fjdBDH"
       >
         Description
       </h2>
     </div>
     <div
-      class="styled__StyledInlineGroup-sc-1a6yr6l-2 eLuDxx"
+      class="styled__StyledInlineGroup-sc-1a6yr6l-2 jiJxde"
     >
       <div>
         <label
-          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 bnFDUS gHnbNN"
+          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 XRfzZ kOhyaa"
           for="bd-textarea-9"
         >
           Description
         </label>
         <span
-          class="styled__StyledTextareaWrapper-sc-c1uos0-0 efPELY"
+          class="styled__StyledTextareaWrapper-sc-c1uos0-0 eavuQn"
         >
           <textarea
-            class="styled__StyledTextarea-sc-c1uos0-1 clZJmO"
+            class="styled__StyledTextarea-sc-c1uos0-1 hkGtZF"
             id="bd-textarea-9"
             name="description"
             placeholder="Product info"
@@ -258,24 +258,24 @@ exports[`Product Info Form renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlex-sc-hcvk8l-0 cyIfaW"
+    class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 fCKsFx"
   >
     <button
-      class="styled__StyledButton-sc-3yq204-0 kuMUbR bd-button"
+      class="styled__StyledButton-sc-3yq204-0 cwQPcK bd-button"
       type="button"
     >
       <span
-        class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+        class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
       >
         Cancel
       </span>
     </button>
     <button
-      class="styled__StyledButton-sc-3yq204-0 hhrqFk bd-button"
+      class="styled__StyledButton-sc-3yq204-0 imcJOf bd-button"
       type="submit"
     >
       <span
-        class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+        class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
       >
         Save
       </span>

--- a/test/pages/products/__snapshots__/index.spec.tsx.snap
+++ b/test/pages/products/__snapshots__/index.spec.tsx.snap
@@ -2,50 +2,50 @@
 
 exports[`Product List renders correctly 1`] = `
 <div
-  class="styled__StyledBox-sc-sj5f1m-0 cmToHM styled__StyledPanel-sc-1h6ef3q-0 dJwQJf"
+  class="styled__StyledBox-sc-sj5f1m-0 odkmb styled__StyledPanel-sc-1h6ef3q-0 gyZFEm"
   id="products"
 >
   <div
     aria-controls="bd-table-1"
-    class="styled__StyledFlex-sc-yxkzj0-0 dwirIV"
+    class="styled__StyledFlex-sc-yxkzj0-0 fPtbUC"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 ebVyxh styled__StyledFlexItem-sc-smjqtt-0 dKgbvr"
+      class="styled__StyledBox-sc-sj5f1m-0 ijVOG styled__StyledFlexItem-sc-smjqtt-0 detsCw"
     >
       <p
-        class="styled__StyledText-sc-tqnj75-5 dHKtpA"
+        class="styled__StyledText-sc-tqnj75-5 kHbLRP"
       >
         5 Products
       </p>
     </div>
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlexItem-sc-smjqtt-0 dKgbvr styled__StyledPaginationContainer-sc-1w0s9nk-0 kWwQla"
+      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 detsCw styled__StyledPaginationContainer-sc-1w0s9nk-0 fTYIdJ"
     >
       <div
         aria-label="pagination"
-        class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlex-sc-hcvk8l-0 fzBpqP"
+        class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 hPcIGA"
         role="navigation"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlexItem-sc-smjqtt-0 hBNgMm"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 jMEPcV"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledBox-sc-2535c9-0 eoUFsY"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
           >
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="bd-dropdown-2-label bd-dropdown-2-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 coPpEc styled__StyledButton-sc-12shuvi-0 eCaiuP"
+              class="styled__StyledButton-sc-3yq204-0 kPIPAr styled__StyledButton-sc-12shuvi-0 gQQcyA"
               id="bd-dropdown-2-toggle-button"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
               >
                 1 - 5 of 5
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 hMuLSB"
+                  class="base__StyledIcon-sc-a9u0e1-0 qCCje"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -64,12 +64,12 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jZjBTX"
+              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
               style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
             >
               <ul
                 aria-labelledby="bd-dropdown-2-label"
-                class="styled__StyledList-sc-5w3dcq-0 iPQrcI"
+                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
                 id="bd-dropdown-2-menu"
                 role="listbox"
                 tabindex="-1"
@@ -78,18 +78,18 @@ exports[`Product List renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlexItem-sc-smjqtt-0 hBNgMm"
+          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 jMEPcV"
         >
           <button
-            class="styled__StyledButton-sc-3yq204-0 gPJsqx styled__StyledButton-sc-12shuvi-0 eCaiuP"
+            class="styled__StyledButton-sc-3yq204-0 jbZfIC styled__StyledButton-sc-12shuvi-0 gQQcyA"
             disabled=""
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
             >
               <svg
                 aria-labelledby="bd-icon-4"
-                class="base__StyledIcon-sc-a9u0e1-0 fLZzZV"
+                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -113,15 +113,15 @@ exports[`Product List renders correctly 1`] = `
             </span>
           </button>
           <button
-            class="styled__StyledButton-sc-3yq204-0 gPJsqx styled__StyledButton-sc-12shuvi-0 eCaiuP"
+            class="styled__StyledButton-sc-3yq204-0 jbZfIC styled__StyledButton-sc-12shuvi-0 gQQcyA"
             disabled=""
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
             >
               <svg
                 aria-labelledby="bd-icon-5"
-                class="base__StyledIcon-sc-a9u0e1-0 fLZzZV"
+                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -149,7 +149,7 @@ exports[`Product List renders correctly 1`] = `
     </div>
   </div>
   <table
-    class="styled__StyledTable-sc-xns2ns-1 fFnuuU"
+    class="styled__StyledTable-sc-xns2ns-1 fHxvLj"
     id="bd-table-1"
   >
     <thead
@@ -157,41 +157,41 @@ exports[`Product List renders correctly 1`] = `
     >
       <tr>
         <th
-          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 dvHkCM"
+          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 epVfVz"
           id="header-cell-0"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlex-sc-hcvk8l-0 kjJEwL styled__StyledFlex-sc-1opnvtt-2 fHZHsY"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1opnvtt-2 gLjYX"
           >
             Product name
           </div>
         </th>
         <th
-          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 dvHkCM"
+          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 epVfVz"
           id="header-cell-1"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlex-sc-hcvk8l-0 kjJEwL styled__StyledFlex-sc-1opnvtt-2 fHZHsY"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1opnvtt-2 gLjYX"
           >
             Stock
           </div>
         </th>
         <th
-          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 dvHkCM"
+          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 epVfVz"
           id="header-cell-2"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlex-sc-hcvk8l-0 kjJEwL styled__StyledFlex-sc-1opnvtt-2 fHZHsY"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1opnvtt-2 gLjYX"
           >
             Price
           </div>
         </th>
         <th
-          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 eCGJDY"
+          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 lfWqzr"
           id="header-cell-3"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledFlex-sc-hcvk8l-0 kjJEwL styled__StyledFlex-sc-1opnvtt-2 clbcZv"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1opnvtt-2 cnzNTE"
           >
             Action
           </div>
@@ -202,51 +202,51 @@ exports[`Product List renders correctly 1`] = `
       class="styled__StyledTableBody-sc-1bwe2hn-0"
     >
       <tr
-        class="styled__StyledTableRow-sc-xq0hr0-0 dgKQdt"
+        class="styled__StyledTableRow-sc-xq0hr0-0 hbJcdW"
       >
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <a
-            class="styled__StyledLink-sc-n9mww9-0 hLvkUi"
+            class="styled__StyledLink-sc-n9mww9-0 kRORmJ"
           >
             Product 0
           </a>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <p
-            class="styled__StyledSmall-sc-tqnj75-6 hzfHcZ"
+            class="styled__StyledSmall-sc-tqnj75-6 cAmSDK"
             color="danger"
           >
             0
           </p>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           $10.00
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledBox-sc-2535c9-0 eoUFsY"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
           >
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="bd-dropdown-10-label bd-dropdown-10-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 gPJsqx bd-button"
+              class="styled__StyledButton-sc-3yq204-0 jbZfIC bd-button"
               id="bd-dropdown-10-toggle-button"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
               >
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 kNdtCN"
+                  class="base__StyledIcon-sc-a9u0e1-0 bSOAMm"
                   color="secondary60"
                   fill="currentColor"
                   height="24"
@@ -266,12 +266,12 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jZjBTX"
+              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <ul
                 aria-labelledby="bd-dropdown-10-label"
-                class="styled__StyledList-sc-5w3dcq-0 iPQrcI"
+                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
                 id="bd-dropdown-10-menu"
                 role="listbox"
                 tabindex="-1"
@@ -281,51 +281,51 @@ exports[`Product List renders correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-xq0hr0-0 dgKQdt"
+        class="styled__StyledTableRow-sc-xq0hr0-0 hbJcdW"
       >
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <a
-            class="styled__StyledLink-sc-n9mww9-0 hLvkUi"
+            class="styled__StyledLink-sc-n9mww9-0 kRORmJ"
           >
             Product 1
           </a>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <p
-            class="styled__StyledSmall-sc-tqnj75-6 hzfHcZ"
+            class="styled__StyledSmall-sc-tqnj75-6 cAmSDK"
             color="danger"
           >
             0
           </p>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           $20.00
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledBox-sc-2535c9-0 eoUFsY"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
           >
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="bd-dropdown-12-label bd-dropdown-12-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 gPJsqx bd-button"
+              class="styled__StyledButton-sc-3yq204-0 jbZfIC bd-button"
               id="bd-dropdown-12-toggle-button"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
               >
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 kNdtCN"
+                  class="base__StyledIcon-sc-a9u0e1-0 bSOAMm"
                   color="secondary60"
                   fill="currentColor"
                   height="24"
@@ -345,12 +345,12 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jZjBTX"
+              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <ul
                 aria-labelledby="bd-dropdown-12-label"
-                class="styled__StyledList-sc-5w3dcq-0 iPQrcI"
+                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
                 id="bd-dropdown-12-menu"
                 role="listbox"
                 tabindex="-1"
@@ -360,51 +360,51 @@ exports[`Product List renders correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-xq0hr0-0 dgKQdt"
+        class="styled__StyledTableRow-sc-xq0hr0-0 hbJcdW"
       >
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <a
-            class="styled__StyledLink-sc-n9mww9-0 hLvkUi"
+            class="styled__StyledLink-sc-n9mww9-0 kRORmJ"
           >
             Product 2
           </a>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <p
-            class="styled__StyledSmall-sc-tqnj75-6 hzfHcZ"
+            class="styled__StyledSmall-sc-tqnj75-6 cAmSDK"
             color="danger"
           >
             0
           </p>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           $30.00
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledBox-sc-2535c9-0 eoUFsY"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
           >
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="bd-dropdown-14-label bd-dropdown-14-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 gPJsqx bd-button"
+              class="styled__StyledButton-sc-3yq204-0 jbZfIC bd-button"
               id="bd-dropdown-14-toggle-button"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
               >
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 kNdtCN"
+                  class="base__StyledIcon-sc-a9u0e1-0 bSOAMm"
                   color="secondary60"
                   fill="currentColor"
                   height="24"
@@ -424,12 +424,12 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jZjBTX"
+              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <ul
                 aria-labelledby="bd-dropdown-14-label"
-                class="styled__StyledList-sc-5w3dcq-0 iPQrcI"
+                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
                 id="bd-dropdown-14-menu"
                 role="listbox"
                 tabindex="-1"
@@ -439,51 +439,51 @@ exports[`Product List renders correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-xq0hr0-0 dgKQdt"
+        class="styled__StyledTableRow-sc-xq0hr0-0 hbJcdW"
       >
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <a
-            class="styled__StyledLink-sc-n9mww9-0 hLvkUi"
+            class="styled__StyledLink-sc-n9mww9-0 kRORmJ"
           >
             Product 3
           </a>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <p
-            class="styled__StyledSmall-sc-tqnj75-6 hzfHcZ"
+            class="styled__StyledSmall-sc-tqnj75-6 cAmSDK"
             color="danger"
           >
             0
           </p>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           $40.00
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledBox-sc-2535c9-0 eoUFsY"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
           >
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="bd-dropdown-16-label bd-dropdown-16-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 gPJsqx bd-button"
+              class="styled__StyledButton-sc-3yq204-0 jbZfIC bd-button"
               id="bd-dropdown-16-toggle-button"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
               >
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 kNdtCN"
+                  class="base__StyledIcon-sc-a9u0e1-0 bSOAMm"
                   color="secondary60"
                   fill="currentColor"
                   height="24"
@@ -503,12 +503,12 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jZjBTX"
+              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <ul
                 aria-labelledby="bd-dropdown-16-label"
-                class="styled__StyledList-sc-5w3dcq-0 iPQrcI"
+                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
                 id="bd-dropdown-16-menu"
                 role="listbox"
                 tabindex="-1"
@@ -518,51 +518,51 @@ exports[`Product List renders correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-xq0hr0-0 dgKQdt"
+        class="styled__StyledTableRow-sc-xq0hr0-0 hbJcdW"
       >
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <a
-            class="styled__StyledLink-sc-n9mww9-0 hLvkUi"
+            class="styled__StyledLink-sc-n9mww9-0 kRORmJ"
           >
             Product 4
           </a>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <p
-            class="styled__StyledSmall-sc-tqnj75-6 hzfHcZ"
+            class="styled__StyledSmall-sc-tqnj75-6 cAmSDK"
             color="danger"
           >
             0
           </p>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           $50.00
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 clMuhg"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 ciDApE styled__StyledBox-sc-2535c9-0 eoUFsY"
+            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
           >
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="bd-dropdown-18-label bd-dropdown-18-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 gPJsqx bd-button"
+              class="styled__StyledButton-sc-3yq204-0 jbZfIC bd-button"
               id="bd-dropdown-18-toggle-button"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 cqsmIZ"
+                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
               >
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 kNdtCN"
+                  class="base__StyledIcon-sc-a9u0e1-0 bSOAMm"
                   color="secondary60"
                   fill="currentColor"
                   height="24"
@@ -582,12 +582,12 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jZjBTX"
+              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <ul
                 aria-labelledby="bd-dropdown-18-label"
-                class="styled__StyledList-sc-5w3dcq-0 iPQrcI"
+                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
                 id="bd-dropdown-18-menu"
                 role="listbox"
                 tabindex="-1"


### PR DESCRIPTION
## What?
Adding in the ability to see an example of App Extensions with the already loaded products list on headerless route product/productId

## Why?
To give app developers  a reference  of App Extensions implementation of it in the Node Sample App

## Testing / Proof
...

https://user-images.githubusercontent.com/109627308/209204736-d68be80b-2ccb-4279-8c38-578633f21c1c.mov



@bigcommerce/api-client-developers
