### PR TITLE
update trialDays prop on plan with proper syntax

### DIFF
--- a/lib/checkout.ts
+++ b/lib/checkout.ts
@@ -39,7 +39,7 @@ const planItems = {
                 currencyCode: 'USD'
             },
         },
-        trial_days: trialDays,
+        trialDays: trialDays,
     },
     '2': {
         product: {
@@ -53,7 +53,7 @@ const planItems = {
                 currencyCode: 'USD',
             },
         },
-        trial_days: trialDays,
+        trialDays: trialDays,
     },
 };
 


### PR DESCRIPTION
## What?
Updated _trial_days_ to _trialDays_ for proper syntax.

## Why?
The trial days property previously used the "trial_days" syntax which was incorrect and ignored but the Checkout Mutation. 

## Testing / Proof
See [syntax documentation](https://bigcommerce.stoplight.io/docs/beta-automated-billing/b35cc8558d171-schema-types#pricingplaninput)

@bigcommerce/api-client-developers
