### PR TITLE
feat(appex): APPEX-515 Create App Ext Reference

### DIFF
--- a/lib/appExtensions.ts
+++ b/lib/appExtensions.ts
@@ -1,0 +1,72 @@
+//  Builds the GraphQL mutation required to create a new App Extension
+export function createAppExtension() {
+    const body = {
+        query: `
+        mutation AppExtension($input: CreateAppExtensionInput!) {
+            appExtension {
+                createAppExtension(input: $input) {
+                appExtension {
+                    id
+                    context
+                    label {
+                    defaultValue
+                    locales {
+                        value
+                        localeCode
+                        }
+                    }
+                    model
+                    url
+                    }
+                }
+            }
+        }`,
+        variables: {
+            input: {
+                context: 'PANEL',
+                model: 'PRODUCTS',
+                url: '/productAppExtension/${id}',
+                label: {
+                    defaultValue: 'View Inside Sample App',
+                    locales: [
+                        {
+                            value: 'View Inside Sample App',
+                            localeCode: 'en-US',
+                        },
+                        {
+                            value: 'Ver dentro de la aplicación de muestra',
+                            localeCode: 'es-ES',
+                        },
+                    ],
+                },
+            },
+        },
+    };
+
+    const requestBody = {
+        query: body.query,
+        variables: body.variables,
+    };
+
+    return requestBody;
+}
+
+// Builds the GraphQL query required to retrieve all App Extensions installed on a store
+export function getAppExtensions() {
+    const body = {
+        query: `
+            query {
+                store {
+                    appExtensions {
+                        edges {
+                            node {
+                                id
+                            }
+                        }
+                    }
+                }
+            }`,
+    };
+
+    return body;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "^28.1.2",
         "jest-environment-jsdom": "^28.1.2",
+        "jest-fetch-mock": "^3.0.3",
         "typescript": "^4.7.3"
       },
       "engines": {
@@ -1093,10 +1094,48 @@
         "@firebase/app-compat": "0.x"
       }
     },
+    "node_modules/@firebase/auth-compat/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/@firebase/auth-compat/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@firebase/auth-compat/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@firebase/auth-compat/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/@firebase/auth-interop-types": {
       "version": "0.1.7",
@@ -1116,10 +1155,48 @@
         "@firebase/util": "1.x"
       }
     },
+    "node_modules/@firebase/auth/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/@firebase/auth/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@firebase/auth/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@firebase/auth/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/@firebase/component": {
       "version": "0.5.21",
@@ -1230,10 +1307,48 @@
         "@firebase/util": "1.x"
       }
     },
+    "node_modules/@firebase/firestore/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/@firebase/firestore/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/@firebase/firestore/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@firebase/firestore/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/@firebase/functions": {
       "version": "0.8.8",
@@ -1277,10 +1392,48 @@
       "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.5.1.tgz",
       "integrity": "sha512-olEJnTuULM/ws0pwhHA0Ze5oIdpFbZsdBGCaBhyL4pm1NUR4Moh0cyAsqr+VtqHCNMGquHU1GJ77qITkoonp0w=="
     },
+    "node_modules/@firebase/functions/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/functions/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/@firebase/functions/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@firebase/functions/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@firebase/functions/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/@firebase/installations": {
       "version": "0.5.16",
@@ -1522,10 +1675,48 @@
         "@firebase/util": "1.x"
       }
     },
+    "node_modules/@firebase/storage/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/storage/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/@firebase/storage/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/@firebase/storage/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@firebase/storage/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/@firebase/util": {
       "version": "1.7.3",
@@ -4887,6 +5078,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
+      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.11"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -8349,6 +8549,16 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
@@ -10910,9 +11120,10 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -10931,17 +11142,20 @@
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -11424,6 +11638,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "dev": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -13675,10 +13895,37 @@
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -13696,10 +13943,37 @@
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -13795,10 +14069,37 @@
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
           "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -13841,10 +14142,37 @@
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -14072,10 +14400,37 @@
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
           "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         }
       }
     },
@@ -16695,6 +17050,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-fetch": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
+      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.11"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -19381,6 +19745,16 @@
         }
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
@@ -21332,9 +21706,10 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -21342,17 +21717,20 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
           "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -21707,6 +22085,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "dev": true
     },
     "prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^28.1.2",
+    "jest-fetch-mock": "^3.0.3",
     "typescript": "^4.7.3"
   }
 }

--- a/pages/api/auth.ts
+++ b/pages/api/auth.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { createAppExtension } from '@lib/appExtensions';
 import { encodePayload, getBCAuth, setSession } from '../../lib/auth';
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
@@ -6,8 +7,34 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
         // Authenticate the app on install
         const session = await getBCAuth(req.query);
         const encodedContext = encodePayload(session); // Signed JWT to validate/ prevent tampering
+        const { access_token: accessToken, context } = session;
+
+        const storeHash = context?.split('/')[1] || '';
 
         await setSession(session);
+
+        /**
+         * For stores that do not have the app installed yet, create App Extensions when app is
+         * installed.
+         */
+
+        const response = await fetch(
+            `https://${process.env.API_URL}/stores/${storeHash}/graphql`,
+            {
+                method: 'POST',
+                headers: {
+                    accept: 'application/json',
+                    'content-type': 'application/json',
+                    'x-auth-token': accessToken,
+                },
+                body: JSON.stringify(createAppExtension()),
+            }
+        );
+        const { errors } = await response.json();
+        if (errors && errors.length > 0) {
+            throw new Error(errors[0]?.message);
+        }
+
         res.redirect(302, `/?context=${encodedContext}`);
     } catch (error) {
         const { message, response } = error;

--- a/pages/api/load.ts
+++ b/pages/api/load.ts
@@ -1,12 +1,16 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { createAppExtension, getAppExtensions } from '@lib/appExtensions';
+import { getStoreToken } from '@lib/dbs/firebase';
 import { encodePayload, getBCVerify, setSession } from '../../lib/auth';
 
 const buildRedirectUrl = (url: string, encodedContext: string) => {
     const [path, query = ''] = url.split('?');
-    const queryParams = new URLSearchParams(`context=${encodedContext}&${query}`);
+    const queryParams = new URLSearchParams(
+        `context=${encodedContext}&${query}`
+    );
 
     return `${path}?${queryParams}`;
-}
+};
 
 export default async function load(req: NextApiRequest, res: NextApiResponse) {
     try {
@@ -14,7 +18,61 @@ export default async function load(req: NextApiRequest, res: NextApiResponse) {
         const session = await getBCVerify(req.query);
         const encodedContext = encodePayload(session); // Signed JWT to validate/ prevent tampering
 
+        const { sub } = session;
+        const storeHash = sub?.split('/')[1] || '';
+
+        const accessToken = await getStoreToken(storeHash);
+
         await setSession(session);
+
+        /**
+         * For stores that do not have app extensions installed yet, create app extensions when app is
+         * loaded
+         */
+
+        const existingAppExtensions = await fetch(
+            `https://${process.env.API_URL}/stores/${storeHash}/graphql`,
+            {
+                method: 'POST',
+                headers: {
+                    accept: 'application/json',
+                    'content-type': 'application/json',
+                    'x-auth-token': accessToken,
+                },
+                body: JSON.stringify(getAppExtensions()),
+            }
+        );
+
+        const { data } = await existingAppExtensions.json();
+
+        const existingAppExtensionIds = data?.store?.appExtensions?.edges;
+
+        // If there are no app extensions returned, we assume we have not
+        // installed app extensions on this store, so we must install them.
+        if (!existingAppExtensionIds?.length) {
+            const createAppExtensionRequest = await createAppExtension();
+
+            // Make fetch to create the app extensions
+            const createResponse = await fetch(
+                `${process.env.API_BASE_URL}/stores/${storeHash}/graphql`,
+                {
+                    method: 'POST',
+                    headers: {
+                        accept: 'application/json',
+                        'content-type': 'application/json',
+                        'x-auth-token': accessToken,
+                    },
+                    body: JSON.stringify(createAppExtensionRequest),
+                }
+            );
+            const response = await createResponse.json();
+
+            // Handel error if app extension creation fails
+            if (response.data === null && response.errors?.length > 0) {
+                throw new Error(response.errors[0]?.message);
+            }
+        }
+
         res.redirect(302, buildRedirectUrl(session.url, encodedContext));
     } catch (error) {
         const { message, response } = error;

--- a/test/pages/__snapshots__/index.spec.tsx.snap
+++ b/test/pages/__snapshots__/index.spec.tsx.snap
@@ -2,59 +2,59 @@
 
 exports[`Homepage renders correctly 1`] = `
 <div
-  class="styled__StyledBox-sc-sj5f1m-0 odkmb styled__StyledPanel-sc-1h6ef3q-0 gyZFEm"
+  class="styled__StyledBox-sc-sj5f1m-0 ddRoJX styled__StyledPanel-sc-1h6ef3q-0 RJZJk"
   id="home"
 >
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 hPcIGA"
+    class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 dEoXps"
   >
     <h2
-      class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 kEGvNd fjdBDH"
+      class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 ilmBBr iRmYTD"
     >
       Homepage
     </h2>
   </div>
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 iYaJla"
+    class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 gCdIQq"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 hdrjpG pages__StyledBox-sc-jwwna7-0 kfGRKK"
+      class="styled__StyledBox-sc-sj5f1m-0 edPngG pages__StyledBox-sc-jwwna7-0 dYpWSa"
     >
       <h4
-        class="styled__StyledH4-sc-tqnj75-4 XRfzZ"
+        class="styled__StyledH4-sc-tqnj75-4 VrTsl"
       >
         Inventory count
       </h4>
       <h1
-        class="styled__StyledH1-sc-tqnj75-1 hetgrk"
+        class="styled__StyledH1-sc-tqnj75-1 dRcaXw"
       >
         3
       </h1>
     </div>
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 hdrjpG pages__StyledBox-sc-jwwna7-0 kfGRKK"
+      class="styled__StyledBox-sc-sj5f1m-0 edPngG pages__StyledBox-sc-jwwna7-0 dYpWSa"
     >
       <h4
-        class="styled__StyledH4-sc-tqnj75-4 XRfzZ"
+        class="styled__StyledH4-sc-tqnj75-4 VrTsl"
       >
         Variant count
       </h4>
       <h1
-        class="styled__StyledH1-sc-tqnj75-1 hetgrk"
+        class="styled__StyledH1-sc-tqnj75-1 dRcaXw"
       >
         2
       </h1>
     </div>
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 bNGvkM pages__StyledBox-sc-jwwna7-0 kfGRKK"
+      class="styled__StyledBox-sc-sj5f1m-0 jHwTSQ pages__StyledBox-sc-jwwna7-0 dYpWSa"
     >
       <h4
-        class="styled__StyledH4-sc-tqnj75-4 XRfzZ"
+        class="styled__StyledH4-sc-tqnj75-4 VrTsl"
       >
         Primary category
       </h4>
       <h1
-        class="styled__StyledH1-sc-tqnj75-1 hetgrk"
+        class="styled__StyledH1-sc-tqnj75-1 dRcaXw"
       >
         widgets
       </h1>

--- a/test/pages/appExtensions.spec.ts
+++ b/test/pages/appExtensions.spec.ts
@@ -1,0 +1,46 @@
+import { FetchMock } from 'jest-fetch-mock';
+import { createAppExtension, getAppExtensions } from '@lib/appExtensions';
+
+const customGlobal: any = global;
+
+const { Response } = jest.requireActual('node-fetch');
+
+customGlobal.fetch = require('jest-fetch-mock');
+customGlobal.fetchResponse = Response;
+
+const fetchMock = customGlobal.fetch as FetchMock;
+
+describe('App Extensions', () => {
+    beforeEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    test('createAppExtension should return a new App Extension request body', async () => {
+        const requestBody = await createAppExtension();
+
+        expect(requestBody).toEqual(
+            expect.objectContaining({
+                query: expect.any(String),
+                variables: expect.any(Object),
+            })
+        );
+
+        expect(requestBody.variables.input).toEqual(
+            expect.objectContaining({
+                context: 'PANEL',
+                model: 'PRODUCTS',
+                url: expect.any(String),
+            })
+        );
+    });
+
+    test('getAppExtensions should return an App Extensions request body', async () => {
+        const requestBody = await getAppExtensions();
+
+        expect(requestBody).toEqual(
+            expect.objectContaining({
+                query: expect.any(String),
+            })
+        );
+    });
+});

--- a/test/pages/productAppExtension/__snapshots__/index.spec.tsx.snap
+++ b/test/pages/productAppExtension/__snapshots__/index.spec.tsx.snap
@@ -2,55 +2,57 @@
 
 exports[`ProductAppExtension renders correctly 1`] = `
 <div
-  class="styled__StyledBox-sc-sj5f1m-0 iiczML styled__StyledPanel-sc-1h6ef3q-0 gyZFEm"
+  class="styled__StyledBox-sc-sj5f1m-0 iWwSMi styled__StyledPanel-sc-1h6ef3q-0 RJZJk"
 >
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 hPcIGA"
+    class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 dEoXps"
   >
     <h2
-      class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 kEGvNd fjdBDH"
+      class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 ilmBBr iRmYTD"
     >
       Basic Information
     </h2>
   </div>
   <h4
-    class="styled__StyledH4-sc-tqnj75-4 XRfzZ"
+    class="styled__StyledH4-sc-tqnj75-4 VrTsl"
   >
     Product name
   </h4>
   <p
-    class="styled__StyledText-sc-tqnj75-5 dCOwSk"
+    class="styled__StyledText-sc-tqnj75-5 TGZwM"
   >
     Product 1
   </p>
   <h4
-    class="styled__StyledH4-sc-tqnj75-4 XRfzZ"
+    class="styled__StyledH4-sc-tqnj75-4 VrTsl"
   >
     Product type
   </h4>
   <p
-    class="styled__StyledText-sc-tqnj75-5 dCOwSk"
+    class="styled__StyledText-sc-tqnj75-5 TGZwM"
   >
     Physical
   </p>
   <h4
-    class="styled__StyledH4-sc-tqnj75-4 XRfzZ"
+    class="styled__StyledH4-sc-tqnj75-4 VrTsl"
   >
     Default price (excluding tax)
   </h4>
   <p
-    class="styled__StyledText-sc-tqnj75-5 dCOwSk"
+    class="styled__StyledText-sc-tqnj75-5 TGZwM"
   >
     $
     20
   </p>
   <h4
-    class="styled__StyledH4-sc-tqnj75-4 XRfzZ"
+    class="styled__StyledH4-sc-tqnj75-4 VrTsl"
   >
     Visible on storefront
   </h4>
   <p
-    class="styled__StyledText-sc-tqnj75-5 dCOwSk"
-  />
+    class="styled__StyledText-sc-tqnj75-5 TGZwM"
+  >
+    False
+  </p>
 </div>
 `;

--- a/test/pages/products/__snapshots__/[pid].spec.tsx.snap
+++ b/test/pages/products/__snapshots__/[pid].spec.tsx.snap
@@ -2,39 +2,39 @@
 
 exports[`Product Info Form renders correctly 1`] = `
 <form
-  class="styled__StyledForm-sc-qzey9b-0 haqnpB"
+  class="styled__StyledForm-sc-qzey9b-0 kcNrat"
 >
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 odkmb styled__StyledPanel-sc-1h6ef3q-0 gyZFEm"
+    class="styled__StyledBox-sc-sj5f1m-0 ddRoJX styled__StyledPanel-sc-1h6ef3q-0 RJZJk"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 hPcIGA"
+      class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 dEoXps"
     >
       <h2
-        class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 kEGvNd fjdBDH"
+        class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 ilmBBr iRmYTD"
       >
         Basic Information
       </h2>
     </div>
     <div
-      class="styled__StyledInlineGroup-sc-1a6yr6l-2 jiJxde"
+      class="styled__StyledInlineGroup-sc-1a6yr6l-2 iETVXG"
     >
       <div>
         <label
-          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 XRfzZ cgVpUS"
-          for="bd-input-1"
+          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 VrTsl iNerfm"
+          for=":r0:"
         >
           Product name
         </label>
         <span
-          class="styled__StyledInputWrapper-sc-g32raa-0 kqLUdD"
+          class="styled__StyledInputWrapper-sc-g32raa-0 gXeHOD"
         >
           <div
-            class="styled__StyledInputContent-sc-g32raa-3 gSfFFG"
+            class="styled__StyledInputContent-sc-g32raa-3 fDViWi"
           >
             <input
-              class="styled__StyledInput-sc-g32raa-1 cYyall"
-              id="bd-input-1"
+              class="styled__StyledInput-sc-g32raa-1 jsyjbp"
+              id=":r0:"
               name="name"
               required=""
               value="Product 1"
@@ -44,119 +44,117 @@ exports[`Product Info Form renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="styled__StyledInlineGroup-sc-1a6yr6l-2 jiJxde"
+      class="styled__StyledInlineGroup-sc-1a6yr6l-2 iETVXG"
     >
       <div>
         <label
-          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 XRfzZ cgVpUS"
-          for="bd-select-2-input"
-          id="bd-select-2-label"
+          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 VrTsl iNerfm"
+          for=":r1:-input"
+          id=":r1:-label"
         >
           Product type
         </label>
         <div
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-owns="bd-select-2-menu"
-          role="combobox"
+          class="styled__StyledInputContainer-sc-1v66t78-2 etcBoi"
         >
-          <div
-            class="styled__StyledInputContainer-sc-1v66t78-2 cwtBIS"
-          >
-            <div>
-              <span
-                class="styled__StyledInputWrapper-sc-g32raa-0 kqLUdD"
+          <div>
+            <span
+              class="styled__StyledInputWrapper-sc-g32raa-0 gXeHOD"
+            >
+              <div
+                class="styled__StyledInputContent-sc-g32raa-3 fDViWi"
               >
-                <div
-                  class="styled__StyledInputContent-sc-g32raa-3 gSfFFG"
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls=":r1:-menu"
+                  aria-expanded="false"
+                  aria-labelledby=":r1:-label"
+                  autocomplete="off"
+                  class="styled__StyledInput-sc-g32raa-1 cLRA-dt"
+                  id=":r1:-input"
+                  name="type"
+                  required=""
+                  role="combobox"
+                  value="Physical"
+                />
+              </div>
+              <div
+                class="styled__StyledIconWrapper-sc-g32raa-2 hmILyZ"
+              >
+                <button
+                  aria-controls=":r1:-menu"
+                  aria-expanded="false"
+                  aria-label="toggle menu"
+                  class="styled__StyledButton-sc-3yq204-0 OOVtf styled__DropdownButton-sc-1v66t78-3 ebVeLS"
+                  id=":r1:-toggle-button"
+                  tabindex="-1"
+                  type="button"
                 >
-                  <input
-                    aria-autocomplete="list"
-                    aria-controls="bd-select-2-menu"
-                    aria-labelledby="bd-select-2-label"
-                    autocomplete="off"
-                    class="styled__StyledInput-sc-g32raa-1 bWoXXx"
-                    id="bd-select-2-input"
-                    name="type"
-                    required=""
-                    value="Physical"
-                  />
-                </div>
-                <div
-                  class="styled__StyledIconWrapper-sc-g32raa-2 jnYXyh"
-                >
-                  <button
-                    aria-label="toggle menu"
-                    class="styled__StyledButton-sc-3yq204-0 gOcBkn styled__DropdownButton-sc-1v66t78-3 fhvqti"
-                    id="bd-select-2-toggle-button"
-                    tabindex="-1"
-                    type="button"
+                  <span
+                    class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
                   >
-                    <span
-                      class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+                    <svg
+                      aria-hidden="true"
+                      class="base__StyledIcon-sc-a9u0e1-0 iUZjCm styled__StyledDropdownIcon-sc-1v66t78-1 cMURAG"
+                      fill="currentColor"
+                      height="24"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 24 24"
+                      width="24"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="base__StyledIcon-sc-a9u0e1-0 bwFIuO styled__StyledDropdownIcon-sc-1v66t78-1 erQgzy"
-                        fill="currentColor"
-                        height="24"
-                        stroke="currentColor"
-                        stroke-width="0"
-                        viewBox="0 0 24 24"
-                        width="24"
-                      >
-                        <path
-                          d="M0 0h24v24H0V0z"
-                          fill="none"
-                        />
-                        <path
-                          d="M8.71 11.71l2.59 2.59c.39.39 1.02.39 1.41 0l2.59-2.59c.63-.63.18-1.71-.71-1.71H9.41c-.89 0-1.33 1.08-.7 1.71z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-              </span>
-            </div>
+                      <path
+                        d="M0 0h24v24H0V0z"
+                        fill="none"
+                      />
+                      <path
+                        d="M8.71 11.71l2.59 2.59c.39.39 1.02.39 1.41 0l2.59-2.59c.63-.63.18-1.71-.71-1.71H9.41c-.89 0-1.33 1.08-.7 1.71z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </span>
           </div>
         </div>
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
+          class="styled__StyledBox-sc-sj5f1m-0 fDrCGs"
           style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 4px);"
         >
           <ul
-            aria-labelledby="bd-select-2-label"
-            class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
-            id="bd-select-2-menu"
+            aria-labelledby=":r1:-label"
+            class="styled__StyledList-sc-5w3dcq-0 gGYksL"
+            id=":r1:-menu"
             role="listbox"
           />
         </div>
       </div>
     </div>
     <div
-      class="styled__StyledInlineGroup-sc-1a6yr6l-2 jiJxde"
+      class="styled__StyledInlineGroup-sc-1a6yr6l-2 iETVXG"
     >
       <div>
         <label
-          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 XRfzZ cgVpUS"
-          for="bd-input-5"
+          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 VrTsl iNerfm"
+          for=":r4:"
         >
           Default price (excluding tax)
         </label>
         <span
-          class="styled__StyledInputWrapper-sc-g32raa-0 kqLUdD"
+          class="styled__StyledInputWrapper-sc-g32raa-0 gXeHOD"
         >
           <div
-            class="styled__StyledIconWrapper-sc-g32raa-2 iEguxa"
+            class="styled__StyledIconWrapper-sc-g32raa-2 jjqqKO"
           >
             $
           </div>
           <div
-            class="styled__StyledInputContent-sc-g32raa-3 gSfFFG"
+            class="styled__StyledInputContent-sc-g32raa-3 fDViWi"
           >
             <input
-              class="styled__StyledInput-sc-g32raa-1 iEJsoi"
-              id="bd-input-5"
+              class="styled__StyledInput-sc-g32raa-1 cZIVUm"
+              id=":r4:"
               name="price"
               placeholder="10.00"
               required=""
@@ -169,26 +167,26 @@ exports[`Product Info Form renders correctly 1`] = `
       </div>
     </div>
     <div
-      class="styled__StyledGroup-sc-1a6yr6l-1 cipyTA"
+      class="styled__StyledGroup-sc-1a6yr6l-1 fHFjzg"
     >
       <div
-        class="styled__CheckboxContainer-sc-s1u0st-1 egATGS"
+        class="styled__CheckboxContainer-sc-s1u0st-1 bGbjQq"
       >
         <input
-          aria-labelledby="bd-checkbox_label-7"
-          class="styled__HiddenCheckbox-sc-s1u0st-2 bXnoDS"
-          id="bd-checkbox-6"
+          aria-labelledby=":r6:"
+          class="styled__HiddenCheckbox-sc-s1u0st-2 ibrtVO"
+          id=":r5:"
           name="isVisible"
           type="checkbox"
         />
         <label
           aria-hidden="true"
-          class="styled__StyledCheckbox-sc-s1u0st-3 Brufm"
-          for="bd-checkbox-6"
+          class="styled__StyledCheckbox-sc-s1u0st-3 cYcfpO"
+          for=":r5:"
         >
           <svg
             aria-hidden="true"
-            class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+            class="base__StyledIcon-sc-a9u0e1-0 iUZjCm"
             fill="currentColor"
             height="24"
             stroke="currentColor"
@@ -206,12 +204,12 @@ exports[`Product Info Form renders correctly 1`] = `
           </svg>
         </label>
         <div
-          class="styled__CheckboxLabelContainer-sc-s1u0st-0 fUhSdv"
+          class="styled__CheckboxLabelContainer-sc-s1u0st-0 cIrPKf"
         >
           <label
-            class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 dCOwSk hcVtt"
-            for="bd-checkbox-6"
-            id="bd-checkbox_label-7"
+            class="styled__StyledText-sc-tqnj75-5 styled__StyledLabel-sc-3soea9-0 TGZwM eJZWDN"
+            for=":r5:"
+            id=":r6:"
           >
             Visible on storefront
           </label>
@@ -220,33 +218,33 @@ exports[`Product Info Form renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 odkmb styled__StyledPanel-sc-1h6ef3q-0 gyZFEm"
+    class="styled__StyledBox-sc-sj5f1m-0 ddRoJX styled__StyledPanel-sc-1h6ef3q-0 RJZJk"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 hPcIGA"
+      class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 dEoXps"
     >
       <h2
-        class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 kEGvNd fjdBDH"
+        class="styled__StyledH2-sc-tqnj75-2 styled__StyledH2-sc-1h6ef3q-1 ilmBBr iRmYTD"
       >
         Description
       </h2>
     </div>
     <div
-      class="styled__StyledInlineGroup-sc-1a6yr6l-2 jiJxde"
+      class="styled__StyledInlineGroup-sc-1a6yr6l-2 iETVXG"
     >
       <div>
         <label
-          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 XRfzZ kOhyaa"
-          for="bd-textarea-9"
+          class="styled__StyledH4-sc-tqnj75-4 styled__StyledLabel-sc-m3fyue-0 VrTsl eKTpGK"
+          for=":r8:"
         >
           Description
         </label>
         <span
-          class="styled__StyledTextareaWrapper-sc-c1uos0-0 eavuQn"
+          class="styled__StyledTextareaWrapper-sc-c1uos0-0 JihVf"
         >
           <textarea
-            class="styled__StyledTextarea-sc-c1uos0-1 hkGtZF"
-            id="bd-textarea-9"
+            class="styled__StyledTextarea-sc-c1uos0-1 bHsLWV"
+            id=":r8:"
             name="description"
             placeholder="Product info"
             rows="3"
@@ -258,24 +256,24 @@ exports[`Product Info Form renders correctly 1`] = `
     </div>
   </div>
   <div
-    class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 fCKsFx"
+    class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 bpmMsp"
   >
     <button
-      class="styled__StyledButton-sc-3yq204-0 cwQPcK bd-button"
+      class="styled__StyledButton-sc-3yq204-0 kXAkG bd-button"
       type="button"
     >
       <span
-        class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+        class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
       >
         Cancel
       </span>
     </button>
     <button
-      class="styled__StyledButton-sc-3yq204-0 imcJOf bd-button"
+      class="styled__StyledButton-sc-3yq204-0 cVsWTD bd-button"
       type="submit"
     >
       <span
-        class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+        class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
       >
         Save
       </span>

--- a/test/pages/products/__snapshots__/index.spec.tsx.snap
+++ b/test/pages/products/__snapshots__/index.spec.tsx.snap
@@ -2,50 +2,54 @@
 
 exports[`Product List renders correctly 1`] = `
 <div
-  class="styled__StyledBox-sc-sj5f1m-0 odkmb styled__StyledPanel-sc-1h6ef3q-0 gyZFEm"
+  class="styled__StyledBox-sc-sj5f1m-0 ddRoJX styled__StyledPanel-sc-1h6ef3q-0 RJZJk"
   id="products"
 >
   <div
-    aria-controls="bd-table-1"
-    class="styled__StyledFlex-sc-yxkzj0-0 fPtbUC"
+    aria-controls=":r0:"
+    class="styled__StyledFlex-sc-yxkzj0-0 iBfqBu"
   >
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 ijVOG styled__StyledFlexItem-sc-smjqtt-0 detsCw"
+      class="styled__StyledBox-sc-sj5f1m-0 cWmZxi styled__StyledFlexItem-sc-smjqtt-0 cNVUGs"
     >
       <p
-        class="styled__StyledText-sc-tqnj75-5 kHbLRP"
+        class="styled__StyledText-sc-tqnj75-5 bnKFFL"
       >
         5 Products
       </p>
     </div>
     <div
-      class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 detsCw styled__StyledPaginationContainer-sc-1w0s9nk-0 fTYIdJ"
+      class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlexItem-sc-smjqtt-0 cNVUGs styled__StyledPaginationContainer-sc-1w0s9nk-0 fEkxvx"
     >
       <div
         aria-label="pagination"
-        class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 hPcIGA"
+        class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 dEoXps"
         role="navigation"
       >
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 jMEPcV"
+          class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlexItem-sc-smjqtt-0 jwhrgR"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
+            class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledBox-sc-2535c9-0 kSUzcL"
           >
             <button
+              aria-activedescendant=""
+              aria-controls=":r1:-menu"
               aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-labelledby="bd-dropdown-2-label bd-dropdown-2-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 kPIPAr styled__StyledButton-sc-12shuvi-0 gQQcyA"
-              id="bd-dropdown-2-toggle-button"
+              aria-haspopup="menu"
+              class="styled__StyledButton-sc-3yq204-0 dRDWiD styled__StyledButton-sc-12shuvi-0 bdkaIM"
+              id=":r1:-toggle-button"
+              role="button"
+              tabindex="0"
+              type="button"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+                class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
               >
                 1 - 5 of 5
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 qCCje"
+                  class="base__StyledIcon-sc-a9u0e1-0 gWUtem"
                   fill="currentColor"
                   height="24"
                   stroke="currentColor"
@@ -64,32 +68,33 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
+              class="styled__StyledBox-sc-sj5f1m-0 fDrCGs"
               style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 4px);"
             >
               <ul
-                aria-labelledby="bd-dropdown-2-label"
-                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
-                id="bd-dropdown-2-menu"
-                role="listbox"
+                aria-labelledby=":r1:-label"
+                class="styled__StyledList-sc-5w3dcq-0 gGYksL"
+                id=":r1:-menu"
+                role="menu"
                 tabindex="-1"
               />
             </div>
           </div>
         </div>
         <div
-          class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlexItem-sc-smjqtt-0 jMEPcV"
+          class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlexItem-sc-smjqtt-0 jwhrgR"
         >
           <button
-            class="styled__StyledButton-sc-3yq204-0 jbZfIC styled__StyledButton-sc-12shuvi-0 gQQcyA"
+            class="styled__StyledButton-sc-3yq204-0 easRXS styled__StyledButton-sc-12shuvi-0 bdkaIM"
             disabled=""
+            type="button"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
             >
               <svg
-                aria-labelledby="bd-icon-4"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                aria-labelledby=":r3:"
+                class="base__StyledIcon-sc-a9u0e1-0 iUZjCm"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -98,7 +103,7 @@ exports[`Product List renders correctly 1`] = `
                 width="24"
               >
                 <title
-                  id="bd-icon-4"
+                  id=":r3:"
                 >
                   Previous page
                 </title>
@@ -113,15 +118,16 @@ exports[`Product List renders correctly 1`] = `
             </span>
           </button>
           <button
-            class="styled__StyledButton-sc-3yq204-0 jbZfIC styled__StyledButton-sc-12shuvi-0 gQQcyA"
+            class="styled__StyledButton-sc-3yq204-0 easRXS styled__StyledButton-sc-12shuvi-0 bdkaIM"
             disabled=""
+            type="button"
           >
             <span
-              class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+              class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
             >
               <svg
-                aria-labelledby="bd-icon-5"
-                class="base__StyledIcon-sc-a9u0e1-0 bwFIuO"
+                aria-labelledby=":r4:"
+                class="base__StyledIcon-sc-a9u0e1-0 iUZjCm"
                 fill="currentColor"
                 height="24"
                 stroke="currentColor"
@@ -130,7 +136,7 @@ exports[`Product List renders correctly 1`] = `
                 width="24"
               >
                 <title
-                  id="bd-icon-5"
+                  id=":r4:"
                 >
                   Next page
                 </title>
@@ -149,49 +155,49 @@ exports[`Product List renders correctly 1`] = `
     </div>
   </div>
   <table
-    class="styled__StyledTable-sc-xns2ns-1 fHxvLj"
-    id="bd-table-1"
+    class="styled__StyledTable-sc-xns2ns-1 jDSVQr"
+    id=":r0:"
   >
     <thead
       class="styled__StyledTableHead-sc-1p8j1x-0"
     >
       <tr>
         <th
-          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 epVfVz"
+          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 kcTQMj"
           id="header-cell-0"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1opnvtt-2 gLjYX"
+            class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 hDRTcY styled__StyledFlex-sc-1opnvtt-2 goSqTz"
           >
             Product name
           </div>
         </th>
         <th
-          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 epVfVz"
+          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 kcTQMj"
           id="header-cell-1"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1opnvtt-2 gLjYX"
+            class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 hDRTcY styled__StyledFlex-sc-1opnvtt-2 goSqTz"
           >
             Stock
           </div>
         </th>
         <th
-          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 epVfVz"
+          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 kcTQMj"
           id="header-cell-2"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1opnvtt-2 gLjYX"
+            class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 hDRTcY styled__StyledFlex-sc-1opnvtt-2 goSqTz"
           >
             Price
           </div>
         </th>
         <th
-          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 lfWqzr"
+          class="styled__StyledTableHeaderCell-sc-1opnvtt-0 kBSYDT"
           id="header-cell-3"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledFlex-sc-hcvk8l-0 dGCTow styled__StyledFlex-sc-1opnvtt-2 cnzNTE"
+            class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledFlex-sc-hcvk8l-0 hDRTcY styled__StyledFlex-sc-1opnvtt-2 muWbY"
           >
             Action
           </div>
@@ -202,51 +208,54 @@ exports[`Product List renders correctly 1`] = `
       class="styled__StyledTableBody-sc-1bwe2hn-0"
     >
       <tr
-        class="styled__StyledTableRow-sc-xq0hr0-0 hbJcdW"
+        class="styled__StyledTableRow-sc-xq0hr0-0 hgtzoq"
       >
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <a
-            class="styled__StyledLink-sc-n9mww9-0 kRORmJ"
+            class="styled__StyledLink-sc-n9mww9-0 jUqmrJ"
           >
             Product 0
           </a>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <p
-            class="styled__StyledSmall-sc-tqnj75-6 cAmSDK"
+            class="styled__StyledSmall-sc-tqnj75-6 ljJUTy"
             color="danger"
           >
             0
           </p>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           $10.00
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
+            class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledBox-sc-2535c9-0 kSUzcL"
           >
             <button
+              aria-activedescendant=""
+              aria-controls=":r9:-menu"
               aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-labelledby="bd-dropdown-10-label bd-dropdown-10-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 jbZfIC bd-button"
-              id="bd-dropdown-10-toggle-button"
+              aria-haspopup="menu"
+              class="styled__StyledButton-sc-3yq204-0 easRXS bd-button"
+              id=":r9:-toggle-button"
+              role="button"
+              tabindex="0"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+                class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
               >
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 bSOAMm"
+                  class="base__StyledIcon-sc-a9u0e1-0 becPjm"
                   color="secondary60"
                   fill="currentColor"
                   height="24"
@@ -266,14 +275,14 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
+              class="styled__StyledBox-sc-sj5f1m-0 fDrCGs"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <ul
-                aria-labelledby="bd-dropdown-10-label"
-                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
-                id="bd-dropdown-10-menu"
-                role="listbox"
+                aria-labelledby=":r9:-label"
+                class="styled__StyledList-sc-5w3dcq-0 gGYksL"
+                id=":r9:-menu"
+                role="menu"
                 tabindex="-1"
               />
             </div>
@@ -281,51 +290,54 @@ exports[`Product List renders correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-xq0hr0-0 hbJcdW"
+        class="styled__StyledTableRow-sc-xq0hr0-0 hgtzoq"
       >
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <a
-            class="styled__StyledLink-sc-n9mww9-0 kRORmJ"
+            class="styled__StyledLink-sc-n9mww9-0 jUqmrJ"
           >
             Product 1
           </a>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <p
-            class="styled__StyledSmall-sc-tqnj75-6 cAmSDK"
+            class="styled__StyledSmall-sc-tqnj75-6 ljJUTy"
             color="danger"
           >
             0
           </p>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           $20.00
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
+            class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledBox-sc-2535c9-0 kSUzcL"
           >
             <button
+              aria-activedescendant=""
+              aria-controls=":rb:-menu"
               aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-labelledby="bd-dropdown-12-label bd-dropdown-12-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 jbZfIC bd-button"
-              id="bd-dropdown-12-toggle-button"
+              aria-haspopup="menu"
+              class="styled__StyledButton-sc-3yq204-0 easRXS bd-button"
+              id=":rb:-toggle-button"
+              role="button"
+              tabindex="0"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+                class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
               >
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 bSOAMm"
+                  class="base__StyledIcon-sc-a9u0e1-0 becPjm"
                   color="secondary60"
                   fill="currentColor"
                   height="24"
@@ -345,14 +357,14 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
+              class="styled__StyledBox-sc-sj5f1m-0 fDrCGs"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <ul
-                aria-labelledby="bd-dropdown-12-label"
-                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
-                id="bd-dropdown-12-menu"
-                role="listbox"
+                aria-labelledby=":rb:-label"
+                class="styled__StyledList-sc-5w3dcq-0 gGYksL"
+                id=":rb:-menu"
+                role="menu"
                 tabindex="-1"
               />
             </div>
@@ -360,51 +372,54 @@ exports[`Product List renders correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-xq0hr0-0 hbJcdW"
+        class="styled__StyledTableRow-sc-xq0hr0-0 hgtzoq"
       >
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <a
-            class="styled__StyledLink-sc-n9mww9-0 kRORmJ"
+            class="styled__StyledLink-sc-n9mww9-0 jUqmrJ"
           >
             Product 2
           </a>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <p
-            class="styled__StyledSmall-sc-tqnj75-6 cAmSDK"
+            class="styled__StyledSmall-sc-tqnj75-6 ljJUTy"
             color="danger"
           >
             0
           </p>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           $30.00
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
+            class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledBox-sc-2535c9-0 kSUzcL"
           >
             <button
+              aria-activedescendant=""
+              aria-controls=":rd:-menu"
               aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-labelledby="bd-dropdown-14-label bd-dropdown-14-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 jbZfIC bd-button"
-              id="bd-dropdown-14-toggle-button"
+              aria-haspopup="menu"
+              class="styled__StyledButton-sc-3yq204-0 easRXS bd-button"
+              id=":rd:-toggle-button"
+              role="button"
+              tabindex="0"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+                class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
               >
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 bSOAMm"
+                  class="base__StyledIcon-sc-a9u0e1-0 becPjm"
                   color="secondary60"
                   fill="currentColor"
                   height="24"
@@ -424,14 +439,14 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
+              class="styled__StyledBox-sc-sj5f1m-0 fDrCGs"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <ul
-                aria-labelledby="bd-dropdown-14-label"
-                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
-                id="bd-dropdown-14-menu"
-                role="listbox"
+                aria-labelledby=":rd:-label"
+                class="styled__StyledList-sc-5w3dcq-0 gGYksL"
+                id=":rd:-menu"
+                role="menu"
                 tabindex="-1"
               />
             </div>
@@ -439,51 +454,54 @@ exports[`Product List renders correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-xq0hr0-0 hbJcdW"
+        class="styled__StyledTableRow-sc-xq0hr0-0 hgtzoq"
       >
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <a
-            class="styled__StyledLink-sc-n9mww9-0 kRORmJ"
+            class="styled__StyledLink-sc-n9mww9-0 jUqmrJ"
           >
             Product 3
           </a>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <p
-            class="styled__StyledSmall-sc-tqnj75-6 cAmSDK"
+            class="styled__StyledSmall-sc-tqnj75-6 ljJUTy"
             color="danger"
           >
             0
           </p>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           $40.00
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
+            class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledBox-sc-2535c9-0 kSUzcL"
           >
             <button
+              aria-activedescendant=""
+              aria-controls=":rf:-menu"
               aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-labelledby="bd-dropdown-16-label bd-dropdown-16-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 jbZfIC bd-button"
-              id="bd-dropdown-16-toggle-button"
+              aria-haspopup="menu"
+              class="styled__StyledButton-sc-3yq204-0 easRXS bd-button"
+              id=":rf:-toggle-button"
+              role="button"
+              tabindex="0"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+                class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
               >
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 bSOAMm"
+                  class="base__StyledIcon-sc-a9u0e1-0 becPjm"
                   color="secondary60"
                   fill="currentColor"
                   height="24"
@@ -503,14 +521,14 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
+              class="styled__StyledBox-sc-sj5f1m-0 fDrCGs"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <ul
-                aria-labelledby="bd-dropdown-16-label"
-                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
-                id="bd-dropdown-16-menu"
-                role="listbox"
+                aria-labelledby=":rf:-label"
+                class="styled__StyledList-sc-5w3dcq-0 gGYksL"
+                id=":rf:-menu"
+                role="menu"
                 tabindex="-1"
               />
             </div>
@@ -518,51 +536,54 @@ exports[`Product List renders correctly 1`] = `
         </td>
       </tr>
       <tr
-        class="styled__StyledTableRow-sc-xq0hr0-0 hbJcdW"
+        class="styled__StyledTableRow-sc-xq0hr0-0 hgtzoq"
       >
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <a
-            class="styled__StyledLink-sc-n9mww9-0 kRORmJ"
+            class="styled__StyledLink-sc-n9mww9-0 jUqmrJ"
           >
             Product 4
           </a>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <p
-            class="styled__StyledSmall-sc-tqnj75-6 cAmSDK"
+            class="styled__StyledSmall-sc-tqnj75-6 ljJUTy"
             color="danger"
           >
             0
           </p>
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           $50.00
         </td>
         <td
-          class="styled__StyledTableDataCell-sc-16y6nzi-0 iCJJdf"
+          class="styled__StyledTableDataCell-sc-16y6nzi-0 kEUlTX"
         >
           <div
-            class="styled__StyledBox-sc-sj5f1m-0 gHBxjL styled__StyledBox-sc-2535c9-0 edhgUr"
+            class="styled__StyledBox-sc-sj5f1m-0 bixGIv styled__StyledBox-sc-2535c9-0 kSUzcL"
           >
             <button
+              aria-activedescendant=""
+              aria-controls=":rh:-menu"
               aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-labelledby="bd-dropdown-18-label bd-dropdown-18-toggle-button"
-              class="styled__StyledButton-sc-3yq204-0 jbZfIC bd-button"
-              id="bd-dropdown-18-toggle-button"
+              aria-haspopup="menu"
+              class="styled__StyledButton-sc-3yq204-0 easRXS bd-button"
+              id=":rh:-toggle-button"
+              role="button"
+              tabindex="0"
             >
               <span
-                class="styled__ContentWrapper-sc-3yq204-1 fwkbqi"
+                class="styled__ContentWrapper-sc-3yq204-1 bLWcGS"
               >
                 <svg
                   aria-hidden="true"
-                  class="base__StyledIcon-sc-a9u0e1-0 bSOAMm"
+                  class="base__StyledIcon-sc-a9u0e1-0 becPjm"
                   color="secondary60"
                   fill="currentColor"
                   height="24"
@@ -582,14 +603,14 @@ exports[`Product List renders correctly 1`] = `
               </span>
             </button>
             <div
-              class="styled__StyledBox-sc-sj5f1m-0 jSPVqw"
+              class="styled__StyledBox-sc-sj5f1m-0 fDrCGs"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <ul
-                aria-labelledby="bd-dropdown-18-label"
-                class="styled__StyledList-sc-5w3dcq-0 dJHrfL"
-                id="bd-dropdown-18-menu"
-                role="listbox"
+                aria-labelledby=":rh:-label"
+                class="styled__StyledList-sc-5w3dcq-0 gGYksL"
+                id=":rh:-menu"
+                role="menu"
                 tabindex="-1"
               />
             </div>


### PR DESCRIPTION
## What?
As part of App Extensions GA, it would be nice to have a corresponding implementation to match the tutorial. This should include API calls to create the app extension (on install/ load) and delete when the app is uninstalled.  As part of this, we should build out products in a similar fashion to orders/orderId whereby the header is scrubbed for display in the side panel.

## Why?
To provide a visual example to go along with the documentation of how App Extensions work within a tutorial.


## Testing / Proof
...

https://github.com/bigcommerce/sample-app-nodejs/assets/109627308/c417f895-c3e9-4413-971f-235913dd8838

https://github.com/bigcommerce/sample-app-nodejs/assets/109627308/0d130914-c01f-45c7-b55e-e807e7df900e


@bigcommerce/api-client-developers
