### PR TITLE
(fix): AccessToken for sql and fb db and .env url

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,31 +1,29 @@
 # Get the Client ID and Secret from the Developer Portal
 # https://developer.bigcommerce.com/api-docs/apps/quick-start#register-a-draft-app
-
 CLIENT_ID={app client id}
 CLIENT_SECRET={app secret}
 
 # Test locally with ngrok
 # https://developer.bigcommerce.com/api-docs/apps/guide/development#testing-locally-with-ngrok
-
 AUTH_CALLBACK=https://{ngrok_id}.ngrok.io/api/auth
 
 # Replace jwt key with a 32+ random character secret
-
 JWT_KEY={SECRET}
 
 # Specify the type of database
 DB_TYPE=firebase
 
 # If using firebase, enter your config here
-
 FIRE_API_KEY={firebase key}
 FIRE_DOMAIN={firebase domain}
 FIRE_PROJECT_ID={firebase project id}
 
 # If using mysql, enter your config here
-
 MYSQL_HOST={mysql host}
 MYSQL_DATABASE={mysql database name}
 MYSQL_USERNAME={mysql username}
 MYSQL_PASSWORD={mysql password}
 MYSQL_PORT={mysql port *optional*}
+
+# BigCommerce API URL
+API_URL=api.bigcommerce.com

--- a/pages/api/load.ts
+++ b/pages/api/load.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { createAppExtension, getAppExtensions } from '@lib/appExtensions';
-import { getStoreToken } from '@lib/dbs/firebase';
+import db from '@lib/db';
 import { encodePayload, getBCVerify, setSession } from '../../lib/auth';
 
 const buildRedirectUrl = (url: string, encodedContext: string) => {
@@ -21,7 +21,7 @@ export default async function load(req: NextApiRequest, res: NextApiResponse) {
         const { sub } = session;
         const storeHash = sub?.split('/')[1] || '';
 
-        const accessToken = await getStoreToken(storeHash);
+        const accessToken = await db.getStoreToken(storeHash);
 
         await setSession(session);
 


### PR DESCRIPTION
## What?
Fix for accessToken request in load for (fb and sql db).  Also added in API url to .env for reference

## Why?
Prior getStoreToken broke for SQL db users.

## Testing / Proof

https://github.com/bigcommerce/sample-app-nodejs/assets/109627308/6d4c054c-340b-418e-8c20-108544f4fa5e



@bigcommerce/api-client-developers
