### PR TITLE
(feat): APPEX-540 check scopes when registering an app extension

### DIFF
--- a/lib/appExtensions.ts
+++ b/lib/appExtensions.ts
@@ -1,5 +1,26 @@
+export const createAppExtension = async ({ accessToken, storeHash }: { accessToken: string, storeHash: string }) => {
+    const response = await fetch(
+        `https://${process.env.API_URL}/stores/${storeHash}/graphql`,
+        {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+            "x-auth-token": accessToken,
+          },
+          body: JSON.stringify(createAppExtensionMutation()),
+        }
+    );
+
+    const { errors } = await response.json();
+  
+    if (errors && errors.length > 0) {
+      throw new Error(errors[0]?.message);
+    }
+}
+
 //  Builds the GraphQL mutation required to create a new App Extension
-export function createAppExtension() {
+export function createAppExtensionMutation() {
     const body = {
         query: `
         mutation AppExtension($input: CreateAppExtensionInput!) {

--- a/lib/dbs/firebase.ts
+++ b/lib/dbs/firebase.ts
@@ -112,3 +112,10 @@ export async function deleteStore({ store_hash: storeHash }: SessionProps) {
 
     await deleteDoc(ref);
 }
+
+export async function hasAppExtensionsScope(storeHash: string): Promise<boolean> {
+    const storeDoc = await getDoc(doc(db, 'store', storeHash));
+    const scopes = storeDoc.data()?.scope ?? '';
+
+    return scopes.includes('store_app_extensions_manage');
+}

--- a/lib/dbs/mysql.ts
+++ b/lib/dbs/mysql.ts
@@ -91,3 +91,10 @@ export async function getStoreToken(storeHash: string) {
 export async function deleteStore({ store_hash: storeHash }: SessionProps) {
     await query('DELETE FROM stores WHERE storeHash = ?', storeHash);
 }
+
+export async function hasAppExtensionsScope(storeHash: string): Promise<boolean> {
+    const scopes = await query('SELECT scope FROM stores WHERE storeHash = ?', storeHash);
+    const row = scopes[0];
+
+    return row?.scope?.includes('store_app_extensions_manage') ?? false;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,8 @@
         "typescript": "^4.7.3"
       },
       "engines": {
-        "node": ">=14 <19",
-        "npm": ">=7.20.x <8.14"
+        "node": ">=14 <20",
+        "npm": ">=7.20.x <9"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/test/pages/appExtensions.spec.ts
+++ b/test/pages/appExtensions.spec.ts
@@ -1,5 +1,5 @@
 import { FetchMock } from 'jest-fetch-mock';
-import { createAppExtension, getAppExtensions } from '@lib/appExtensions';
+import { createAppExtensionMutation, getAppExtensions } from '@lib/appExtensions';
 
 const customGlobal: any = global;
 
@@ -16,7 +16,7 @@ describe('App Extensions', () => {
     });
 
     test('createAppExtension should return a new App Extension request body', async () => {
-        const requestBody = await createAppExtension();
+        const requestBody = await createAppExtensionMutation();
 
         expect(requestBody).toEqual(
             expect.objectContaining({

--- a/types/db.ts
+++ b/types/db.ts
@@ -12,11 +12,12 @@ export interface UserData {
 }
 
 export interface Db {
-    hasStoreUser(storeHash: string, userId: string): Promise<boolean> | boolean;
+    hasStoreUser(storeHash: string, userId: string): Promise<boolean>;
     setUser(session: SessionProps): Promise<void>;
     setStore(session: SessionProps): Promise<void>;
     setStoreUser(session: SessionProps): Promise<void>;
     getStoreToken(storeId: string): Promise<string> | null;
     deleteStore(session: SessionProps): Promise<void>;
     deleteUser(session: SessionProps): Promise<void>;
+    hasAppExtensionsScope(storeHash: string): Promise<boolean>;
 }


### PR DESCRIPTION
## What?
Add logs when app extensions scope is missing.

## Why?
Check to see if the app has the appropriate scope (app extensions) enabled to register an app extension.

## Testing / Proof
Tested locally with both mysql and firebase dbs

**Showing logs when app extensions scope is missing**

https://github.com/bigcommerce/sample-app-nodejs/assets/39739180/219e44e6-8ced-4f9b-bc11-a87ad5f0d25b


**Not showing logs when scope exists**

https://github.com/bigcommerce/sample-app-nodejs/assets/39739180/fa18f820-1171-4cbd-ae1f-4a481734951f







@bigcommerce/api-client-developers
