### PR TITLE
chore(common): Remove node 16 build

### DIFF
--- a/.github/workflows/validate-workflow.yml
+++ b/.github/workflows/validate-workflow.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This starter app includes all the files necessary to get started with a basic, h
 
 To get the app running locally, follow these instructions:
 
-1. [Use Node 16+ and NPM 8+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#checking-your-version-of-npm-and-node-js). To check the running versions, use the following commands:
+1. [Use Node 18+ and NPM 8+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#checking-your-version-of-npm-and-node-js). To check the running versions, use the following commands:
 
 ```shell
 node -v

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": ">=16 <20",
+    "node": ">=18 <20",
     "npm": ">=8 <10"
   },
   "dependencies": {


### PR DESCRIPTION
## What?
Remove testing/support for node 16 (post-EOL)

## Why?
Node 16 is EOL.

@bigcommerce/api-client-developers
