### PR TITLE
Refactor db.ts for conditional database imports

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,20 +1,20 @@
 import { Db } from '../types';
-import * as firebaseDB from './dbs/firebase';
-import * as sqlDB from './dbs/mysql';
 
 const { DB_TYPE } = process.env;
 
 let db: Db;
+const dbType = DB_TYPE || 'firebase';
 
-switch (DB_TYPE) {
+switch (dbType) {
     case 'firebase':
-        db = firebaseDB;
+        // Use require for conditional import
+        db = require('./dbs/firebase');
         break;
     case 'mysql':
-        db = sqlDB;
+        db = require('./dbs/mysql');
         break;
     default:
-        db = firebaseDB;
+        db = require('./dbs/firebase');
         break;
 }
 


### PR DESCRIPTION
Refactor database import to use require for conditional loading based on DB_TYPE.

## What?
Getting error when `DB_TYPE` is set to `mysql`.
FirebaseAppError: Failed to parse private key: Error: Invalid PEM formatted message. at new ServiceAccount

## Why?
Fix error when using mysql

## Testing / Proof
No error after this change when using mysql

@bigcommerce/api-client-developers
